### PR TITLE
Feat/student_progress

### DIFF
--- a/classes/restclient.php
+++ b/classes/restclient.php
@@ -169,14 +169,8 @@ class restclient {
             $params['usernames'] = implode(',', $usernames);
         }
 
-        try {
-            $response = $this->client->get($progress_url, $params);
-            return $this->handle_response($response);
-        } catch (Exception $e) {
-            // Log the error and return empty array
-            error_log("SelfLearn API Error: " . $e->getMessage());
-            return [];
-        }
+        $response = $this->client->get($progress_url, $params);
+        return $this->handle_response($response);
     }
 }
 

--- a/classes/restclient.php
+++ b/classes/restclient.php
@@ -133,17 +133,41 @@ class restclient {
     
     function selflearn_get_course_title($slug) {
         $lms_url = $this->selflearn_rest_api . "courses/" . $slug;
-    
+
         // Query
         $response = $this->client->get($lms_url);
         $http_status = $this->client->get_info()['http_code'];
-        
+
         if ($http_status == 404) {
             // Course data not found for given slug, use fallback "Course: slug"
             return get_string("activity_prefix_course", 'selflearn') . $slug;
         } else {
             $data = $this->handle_response($response);
             return $data['title'];
+        }
+    }
+
+    /**
+     * Get course progress for multiple students
+     * @param string $slug Course slug
+     * @param array $usernames Array of student usernames
+     * @return array Array of progress data with username and progress percentage
+     */
+    function selflearn_get_course_progress($slug, $usernames) {
+        $progress_url = $this->selflearn_rest_api . "courses/" . $slug . "/progress";
+
+        $params = [];
+        if (!empty($usernames)) {
+            $params['usernames'] = implode(',', $usernames);
+        }
+
+        try {
+            $response = $this->client->get($progress_url, $params);
+            return $this->handle_response($response);
+        } catch (Exception $e) {
+            // Log the error and return empty array
+            error_log("SelfLearn API Error: " . $e->getMessage());
+            return [];
         }
     }
 }

--- a/classes/restclient.php
+++ b/classes/restclient.php
@@ -24,19 +24,27 @@ class restclient {
         $config = get_config('mod_selflearn');
         
         if (empty($config->selflearn_base_url)) {
-            throw new Exception(get_string("error::No SelfLearn Base URL configured", "mod_selflearn"));
+            throw new Exception(get_string("error::No_SelfLearn_Base_URL_configured", "mod_selflearn"));
         }
         $this->selflearn_website = $config->selflearn_base_url;
         $this->selflearn_rest_api = $config->selflearn_base_url . REST_API;
         
         // Load OAuth2 service, which is configured to be used with this plugin
         if (empty($config->selflearn_oauth2_provider)) {
-            throw new Exception(get_string("error::No OAuth2 provider configured", "mod_selflearn"));
+            error_log("SelfLearn: No OAuth2 provider configured.");
+            throw new Exception(get_string("error::No_OAuth2_provider_configured", "mod_selflearn"));
         } 
 
         // Get sertvice account
         $api = new api();
-        $issuer = $api->get_issuer($config->selflearn_oauth2_provider);
+        try {
+            $issuer = $api->get_issuer($config->selflearn_oauth2_provider);
+        } catch (moodle_exception $e) {
+            // Will throw dml_missing_record_exception, if issuer was not found
+            // or invalid/outdated provider was selected
+            error_log("SelfLearn: Wrong (probably non-existend) OAuth2 provider configured, with id = {$config->selflearn_oauth2_provider}");
+            throw new Exception(get_string("error::OAuth2_misconfigured", "mod_selflearn"));
+        }
 
         // Load OAuth2 client
         $current_page = $PAGE->url->out_as_local_url(false);

--- a/coursereport.php
+++ b/coursereport.php
@@ -1,160 +1,436 @@
 <?php
-// require_once("../../config.php");
-// require_once("lib.php");
+/**
+ * SelfLearn Progress Report - Minimalistic Professional Design
+ * Shows detailed progress overview for all students in SelfLearn activities
+ *
+ * @package   selflearn
+ * @copyright 2024 University of Hildesheim, Software Systems Engineering
+ * @license   Apache License 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ */
 
-// $id = required_param('id', PARAM_INT); // Course Id.
-// $cache = cache::make('mod_selflearn', 'report_cache');
+require_once("../../config.php");
+require_once("lib.php");
 
-// // Access + permissions.
-// $course = get_course($id);
-// // Verify the user has access to view the coursle
-// require_login($id);
+$id = required_param('id', PARAM_INT);
+$sortby = optional_param('sortby', '0', PARAM_INT);
+$sortorder = optional_param('sortorder', 'ASC', PARAM_ALPHA);
+$refresh = optional_param('refresh', 0, PARAM_INT);
+$page = optional_param('page', 1, PARAM_INT);
+$perpage = optional_param('perpage', 25, PARAM_INT);
+$search = optional_param('search', '', PARAM_TEXT);
 
-// $context = context_course::instance($id);
-// require_capability('mod/selflearn:viewgrades', $context);
+// Access + permissions
+$course = get_course($id);
+require_login($id);
 
-// // Fetch the enrolled users in the course
-// $enrolled_users = get_enrolled_users($context);
-// $sortby = optional_param('sortby', '0', PARAM_INT);
-// $sortorder = optional_param('sortorder', 'ASC', PARAM_ALPHA);
+$context = context_course::instance($id);
+require_capability('moodle/grade:viewall', $context);
 
-// // Determine the next sort order for the links
-// $nextsortorder = ($sortorder == 'ASC') ? 'DESC' : 'ASC';
+// Cache setup
+$cache = cache::make('mod_selflearn', 'report_cache');
 
-// // Fetch course module information
-// $modinfo = get_fast_modinfo($id);
+if ($refresh) {
+    $cache->delete($id);
+}
 
-// // Specify the module name of the current plugin (e.g., 'mymodule' for mod_mymodule)
-// $modulename = 'selflearn';
+// Fetch enrolled users
+$enrolled_users = get_enrolled_users($context);
+$nextsortorder = ($sortorder == 'ASC') ? 'DESC' : 'ASC';
 
-// // Get all activities in the course for the specified plugin
-// global $DB;
-// $courses = [];
-// $instances = [];
-// foreach ($modinfo->get_instances_of($modulename) as $cm) {
-//     if ($cm->uservisible) {
-//         $info = $DB->get_record('selflearn', ['id' => $cm->instance]);
-//         // Only include visible activities
-//         $instances[] = [
-//             'name' => $cm->name,
-//             'id' => $cm->id,
-//             'url' => new moodle_url('/mod/' . $modulename . '/view.php', ['id' => $cm->id]),
-//             'slug' => $info->slug
-//         ];
-//         $courses[] = ["slug" => $info->slug, "id" => $info->id];
-//     }
-// }
+// Fetch course module information
+$modinfo = get_fast_modinfo($id);
+$modulename = 'selflearn';
 
-// // Query progress for all enrolled students for all SelfLearn activities
-// $studentRoleId = 5;  // Student role ID (typically 5)
-// $students = [];
-// foreach ($enrolled_users as $user) {
-//     if (user_has_role_assignment($user->id, $studentRoleId, $context->id)) {
-//         $student = new stdClass();
-//         $student->username = $user->username;
-//         $student->firstname = $user->firstname;
-//         $student->lastname = $user->lastname;
-//         $students[] = $student;
-//     }
-// }
+// Get all activities
+global $DB;
+$courses = [];
+$instances = [];
+foreach ($modinfo->get_instances_of($modulename) as $cm) {
+    if ($cm->uservisible) {
+        $info = $DB->get_record('selflearn', ['id' => $cm->instance]);
+        $instances[] = [
+            'name' => $cm->name,
+            'id' => $cm->id,
+            'url' => new moodle_url('/mod/' . $modulename . '/view.php', ['id' => $cm->id]),
+            'slug' => $info->slug
+        ];
+        $courses[] = ["slug" => $info->slug, "id" => $info->id];
+    }
+}
 
-// if (empty($students)) {
-//     // No students found, display a message
-//     echo $OUTPUT->header();
-//     echo $OUTPUT->heading(get_string("report::no_students", "selflearn"));
-//     echo $OUTPUT->footer();
-//     die();
-// }
-// if (empty($courses)) {
-//     // No selflearn activities defined, display a message
-//     echo $OUTPUT->header();
-//     echo $OUTPUT->heading(get_string("report::no_activities", "selflearn"));
-//     echo $OUTPUT->footer();
-//     die();
-// }
+// Get students
+$studentRoleId = 5;
+$students = [];
+foreach ($enrolled_users as $user) {
+    if (user_has_role_assignment($user->id, $studentRoleId, $context->id)) {
+        $student = new stdClass();
+        $student->username = $user->username;
+        $student->firstname = $user->firstname;
+        $student->lastname = $user->lastname;
+        $students[] = $student;
+    }
+}
 
-// $merged = [];
-// $data = $cache->get($id);
-// if ($data === false) {
-//     $progress = selflearn_query_progress($students, $courses);
+if (empty($students)) {
+    echo $OUTPUT->header();
+    echo $OUTPUT->heading(get_string("report::no_students", "selflearn"));
+    echo $OUTPUT->footer();
+    die();
+}
+
+if (empty($courses)) {
+    echo $OUTPUT->header();
+    echo $OUTPUT->heading(get_string("report::no_activities", "selflearn"));
+    echo $OUTPUT->footer();
+    die();
+}
+
+// Get or compute progress data
+$merged = [];
+$data = $cache->get($id);
+
+if ($data === false || $refresh) {
+    $progress = selflearn_query_progress($students, $courses);
+
+    foreach ($students as $user) {
+        $combined = [
+            $user->firstname,
+            $user->lastname,
+            $user->username
+        ];
+
+        foreach ($courses as $course) {
+            $slug = $course['slug'];
+
+            if (isset($progress[$user->username]) && isset($progress[$user->username][$slug])) {
+                $value = $progress[$user->username][$slug];
+                if ($value === null || $value === false || $value === "---") {                    
+                    $combined[] = '---';
+                } else {
+                    $combined[] = intval($value);
+                }
+            } else {
+                $combined[] = '---';
+            }
+        }
+
+        if (isset($progress[$user->username]['total_average'])) {
+            $avg = $progress[$user->username]['total_average'];
+            $combined[] = ($avg !== null && $avg !== false) ? intval($avg) : '---';
+        } else {
+            $combined[] = '---';
+        }
+
+        $merged[] = $combined;
+    }
+
+    $data = new stdClass();
+    $data->data = $merged;
+    $data->courses = array_column($instances, 'name');
+    $data->last_updated = time();
+
+    $cache->set($id, $data);
+} else {
+    $merged = $data->data;
+}
+
+// Apply search filter
+$filtered = $merged;
+if (!empty($search)) {
+    $search_lower = strtolower(trim($search));
+    $filtered = array_filter($merged, function($entry) use ($search_lower) {
+        $firstname = strtolower($entry[0]);
+        $lastname = strtolower($entry[1]);
+        $username = strtolower($entry[2]);
+        
+        return (strpos($firstname, $search_lower) !== false ||
+                strpos($lastname, $search_lower) !== false ||
+                strpos($username, $search_lower) !== false);
+    });
+    $filtered = array_values($filtered);
+}
+
+// Sort data
+usort($filtered, function($a, $b) use ($sortby, $sortorder) {
+    $index = $sortby;
+    if ($index == 0 || $index == 1 || $index == 2) {
+        return $sortorder == 'ASC' ? strcmp($a[$index], $b[$index]) : strcmp($b[$index], $a[$index]);
+    }
+
+    $aVal = ($a[$index] === '---' || $a[$index] === 'N/A') ? -1 : intval($a[$index]);
+    $bVal = ($b[$index] === '---' || $b[$index] === 'N/A') ? -1 : intval($b[$index]);
+
+    return $sortorder == 'ASC' ? $aVal <=> $bVal : $bVal <=> $aVal;
+});
+
+// Calculate pagination
+$total_records = count($filtered);
+$total_pages = ceil($total_records / $perpage);
+$page = max(1, min($page, $total_pages));
+$offset = ($page - 1) * $perpage;
+$paginated_data = array_slice($filtered, $offset, $perpage);
+
+// Calculate statistics
+$total_students = count($filtered);
+$enrolled_students = 0;
+$total_progress = 0;
+$progress_count = 0;
+
+foreach ($filtered as $entry) {
+    $has_any_enrollment = false;
     
-//     foreach ($students as $user) {
-//         // Init array with user data
-//         $combined = [
-//             $user->firstname,
-//             $user->lastname
-//         ];
+    for ($i = 3; $i < count($entry) - 1; $i++) {
+        if ($entry[$i] !== '---' && $entry[$i] !== 'N/A') {
+            $has_any_enrollment = true;
+            $progress_value = intval($entry[$i]);
+            $total_progress += $progress_value;
+            $progress_count++;
+        }
+    }
 
-//         // Search for the progress of the user for each SelfLearn activity
-//         foreach ($courses as $course) {
-//             $slug = $course['slug'];
-//             $value = $progress[$user->username][$slug];
-//             $combined[] = $value;
-//         }
-//         $combined[] = $progress[$user->username]['total_average'];
+    if ($has_any_enrollment) {
+        $enrolled_students++;
+    }
+}
 
-//         // Combine data
-//         $merged[] = $combined;
-//     }
+$avg_progress = ($progress_count > 0) ? round($total_progress / $progress_count, 1) : 0;
+
+// Page setup
+global $PAGE, $OUTPUT;
+$pagetitle = get_string("report::title", "selflearn");
+$pageurl = new moodle_url('/mod/selflearn/coursereport.php', [
+    'id' => $id, 
+    'sortby' => $sortby, 
+    'sortorder' => $sortorder,
+    'page' => $page,
+    'perpage' => $perpage,
+    'search' => $search
+]);
+$PAGE->set_pagelayout('incourse');
+$PAGE->set_context($context);
+$PAGE->set_url($pageurl);
+$PAGE->set_title($pagetitle);
+$PAGE->set_heading(format_string($course->fullname, true, ['context' => $context]));
+$PAGE->add_body_class('limitedwidth');
+
+$PAGE->requires->css('/mod/selflearn/styles.css');
+
+echo $OUTPUT->header();
+echo $OUTPUT->heading($pagetitle);
+
+// Last updated info
+if (isset($data->last_updated)) {
+    $last_updated = userdate($data->last_updated, get_string('strftimerecent'));
+    echo '<div class="alert-info">';
+    echo '<p><strong>' . get_string('report::last_updated', 'selflearn') . '</strong> ' . $last_updated . '</p>';
+    echo '<p>' . get_string('report::cache_info', 'selflearn') . '</p>';
+    echo '</div>';
+}
+
+echo '<div class="report-wrapper">';
+
+// Top Statistics Bar
+echo '<div class="top-stats-bar">';
+
+echo '<div class="stat-box">';
+echo '<div class="stat-box-label">' . get_string('report::total_students', 'selflearn') . '</div>';
+echo '<div class="stat-box-value">' . $total_students . '</div>';
+echo '</div>';
+
+echo '<div class="stat-box">';
+echo '<div class="stat-box-label">' . get_string('report::enrolled_students', 'selflearn') . '</div>';
+echo '<div class="stat-box-value">' . $enrolled_students . '</div>';
+echo '</div>';
+
+echo '<div class="stat-box">';
+echo '<div class="stat-box-label">' . get_string('report::average_progress', 'selflearn') . '</div>';
+echo '<div class="stat-box-value">' . $avg_progress . '%</div>';
+echo '</div>';
+
+echo '<div class="stat-box">';
+echo '<div class="stat-box-label">' . get_string('report::activities_count', 'selflearn') . '</div>';
+echo '<div class="stat-box-value">' . count($instances) . '</div>';
+echo '</div>';
+
+echo '</div>';
+
+// Controls Section
+echo '<div class="controls-section">';
+
+echo '<div class="search-container">';
+echo '<form method="get" action="' . $pageurl->out_omit_querystring() . '">';
+echo '<input type="hidden" name="id" value="' . $id . '">';
+echo '<input type="hidden" name="sortby" value="' . $sortby . '">';
+echo '<input type="hidden" name="sortorder" value="' . $sortorder . '">';
+echo '<input type="text" name="search" class="search-input" placeholder="' . get_string('report::search_placeholder', 'selflearn') . '" value="' . s($search) . '">';
+echo '</form>';
+echo '</div>';
+
+echo '<div class="action-buttons">';
+$refreshurl = new moodle_url('/mod/selflearn/coursereport.php', ['id' => $id, 'refresh' => 1]);
+echo html_writer::link($refreshurl, get_string('report::refresh_data', 'selflearn'), ['class' => 'btn btn-secondary']);
+$exporturl = new moodle_url('/mod/selflearn/excelexport.php', ['id' => $id]);
+echo html_writer::link($exporturl, get_string('report::export_btn', 'selflearn'), ['class' => 'btn btn-primary']);
+echo '</div>';
+
+echo '</div>';
+
+// Progress table
+if (empty($paginated_data)) {
+    echo '<div class="no-results">';
+    echo '<p>' . get_string('report::no_results', 'selflearn') . '</p>';
+    echo '</div>';
+} else {
+    echo '<div class="table-container">';
+    echo '<div class="table-responsive">';
+    echo '<table class="table selflearn_table">';
+    echo '<thead>';
+    echo '<tr>';
+
+    $baseParams = ['id' => $id, 'page' => $page, 'perpage' => $perpage, 'search' => $search, 'sortorder' => $nextsortorder];
     
-//     $data = new stdClass();
-//     $data->data = $merged;
-//     $data->courses = array_column($instances, 'name');
+    $firstNameUrl = new moodle_url('/mod/selflearn/coursereport.php', array_merge($baseParams, ['sortby' => 0]));
+    echo '<th><a href="' . $firstNameUrl . '">' . get_string("report::first_name", "selflearn");
+    if ($sortby == 0) echo ($sortorder == 'ASC') ? ' ↑' : ' ↓';
+    echo '</a></th>';
 
-//     // Store the computed data in the cache
-//     $cache->set($id, $data);
-// } else {
-//     $merged = $data->data;
-// }
+    $lastNameUrl = new moodle_url('/mod/selflearn/coursereport.php', array_merge($baseParams, ['sortby' => 1]));
+    echo '<th><a href="' . $lastNameUrl . '">' . get_string("report::last_name", "selflearn");
+    if ($sortby == 1) echo ($sortorder == 'ASC') ? ' ↑' : ' ↓';
+    echo '</a></th>';
 
-// usort($merged, function($a, $b) use ($sortby, $sortorder) {
-//     $index = $sortby;
-//     if ($index == 0 || $index == 1) {
-//         return $sortorder == 'ASC' ? strcmp($a[$index], $b[$index]) : strcmp($b[$index], $a[$index]);
-//     }
-//     return $sortorder == 'ASC' ? $a[$index] <=> $b[$index] : $b[$index] <=> $a[$index];
-// });
+    $usernameUrl = new moodle_url('/mod/selflearn/coursereport.php', array_merge($baseParams, ['sortby' => 2]));
+    echo '<th><a href="' . $usernameUrl . '">' . get_string('report::username', 'selflearn');
+    if ($sortby == 2) echo ($sortorder == 'ASC') ? ' ↑' : ' ↓';
+    echo '</a></th>';
 
-// // Page setup.
-// global $PAGE, $OUTPUT;
-// $pagetitle = get_string("report::title", "selflearn");
-// $pageurl = new moodle_url('/mod/selflearn/coursereport.php', ['id' => $id, 'sortby' => $sortby, 'sortorder' => $sortorder]);
-// $PAGE->set_pagelayout('incourse');
-// $PAGE->set_context($context);
-// $PAGE->set_url($pageurl);
-// $PAGE->set_title($pagetitle);
-// $PAGE->set_heading(format_string($course->fullname, true, ['context' => $context]));
-// $PAGE->add_body_class('limitedwidth');
+    for ($i = 0; $i < count($instances); $i++) {
+        $activityUrl = new moodle_url('/mod/selflearn/coursereport.php', array_merge($baseParams, ['sortby' => ($i + 3)]));
+        echo '<th><a href="' . $activityUrl . '">' . $instances[$i]["name"];
+        if ($sortby == ($i + 3)) echo ($sortorder == 'ASC') ? ' ↑' : ' ↓';
+        echo '</a></th>';
+    }
 
+    $avgUrl = new moodle_url('/mod/selflearn/coursereport.php', array_merge($baseParams, ['sortby' => (count($instances) + 3)]));
+    echo '<th><a href="' . $avgUrl . '">' . get_string('report::average', 'selflearn');
+    if ($sortby == (count($instances) + 3)) echo ($sortorder == 'ASC') ? ' ↑' : ' ↓';
+    echo '</a></th>';
 
-// // Display.
-// echo $OUTPUT->header();
-// echo $OUTPUT->heading($pagetitle);
+    echo '</tr>';
+    echo '</thead>';
+    echo '<tbody>';
 
-// echo '<table class="selflearn_table">';
-// echo '<tr>';
-// $fistNameUrl = new moodle_url('/mod/selflearn/coursereport.php', ['id' => $id, 'sortby' => 0, 'sortorder' => $nextsortorder]);
-// echo '<th><a href="' . $fistNameUrl . '">' . get_string("report::first_name", "selflearn") . '</a></th>';
-// echo '<th><a href="?id=' . $id . '&sortby=1&sortorder=' . $nextsortorder . '">' . get_string("report::last_name", "selflearn") . '</a></th>';
-// for ($i = 0; $i < count($instances); $i++) {
-//     echo '<th><a href="?id=' . $id . '&sortby=' . ($i + 2) . '&sortorder=' . $nextsortorder . '">' . $instances[$i]["name"] .'</a></th>';
-// }
-// echo '<th><a href="?id=' . $id . '&sortby=' . (count($instances) + 2) . '&sortorder=' . $nextsortorder . '">Σ</a></th>';
-// echo '</tr>';
-// // Loop through each enrolled user and display their data in the table
-// foreach ($merged as $entry) {
-//     echo '<tr>';
-//     for ($i = 0; $i < count($entry); $i++) {
-//         echo '<td>' . $entry[$i] . '</td>';
-//     }
-//     echo '</tr>';
-// }
-// echo '</table>';
+    foreach ($paginated_data as $entry) {
+        echo '<tr>';
+        for ($i = 0; $i < count($entry); $i++) {
+            $value = $entry[$i];
 
-// echo html_writer::link(
-//     new moodle_url('/mod/selflearn/excelexport.php?id=' . $id), 
-//     get_string("report::export_btn", "selflearn"), 
-//     ['class' => 'btn btn-primary']
-// );
+            if ($i >= 3) {
+                if ($value === '---' || $value === 'N/A') {
+                    echo '<td class="text-muted"><em>' . $value . '</em></td>';
+                } else {
+                    $percentage = intval($value);
+                    $class = '';
+                    if ($percentage >= 80) $class = 'text-success';
+                    elseif ($percentage >= 60) $class = 'text-warning';
+                    elseif ($percentage >= 0) $class = 'text-danger';
+                    else $class = 'text-muted';
 
-// echo $OUTPUT->footer();
+                    echo '<td class="' . $class . '"><strong>' . $percentage . '%</strong></td>';
+                }
+            } else {
+                echo '<td>' . htmlspecialchars($value) . '</td>';
+            }
+        }
+        echo '</tr>';
+    }
+
+    echo '</tbody>';
+    echo '</table>';
+    echo '</div>';
+    echo '</div>';
+
+    // Bottom Section: Pagination + Legend
+    echo '<div class="bottom-section">';
+    
+    // Pagination
+    echo '<div class="pagination-wrapper">';
+    
+    if ($total_pages > 1) {
+        echo '<div class="pagination-container">';
+        
+        $start = $offset + 1;
+        $end = min($offset + $perpage, $total_records);
+        echo '<div class="pagination-info">';
+        echo get_string('report::showing_entries', 'selflearn', ['start' => $start, 'end' => $end, 'total' => $total_records]);
+        echo '</div>';
+        
+        echo '<ul class="pagination">';
+        
+        $paginationParams = ['id' => $id, 'sortby' => $sortby, 'sortorder' => $sortorder, 'perpage' => $perpage, 'search' => $search];
+        
+        if ($page > 1) {
+            $prevUrl = new moodle_url('/mod/selflearn/coursereport.php', array_merge($paginationParams, ['page' => ($page - 1)]));
+            echo '<li><a href="' . $prevUrl . '">' . get_string('report::previous', 'selflearn') . '</a></li>';
+        } else {
+            echo '<li class="disabled"><span>' . get_string('report::previous', 'selflearn') . '</span></li>';
+        }
+        
+        $start_page = max(1, $page - 2);
+        $end_page = min($total_pages, $page + 2);
+        
+        if ($start_page > 1) {
+            $firstUrl = new moodle_url('/mod/selflearn/coursereport.php', array_merge($paginationParams, ['page' => 1]));
+            echo '<li><a href="' . $firstUrl . '">1</a></li>';
+            if ($start_page > 2) {
+                echo '<li class="disabled"><span>...</span></li>';
+            }
+        }
+        
+        for ($i = $start_page; $i <= $end_page; $i++) {
+            $pageNumUrl = new moodle_url('/mod/selflearn/coursereport.php', array_merge($paginationParams, ['page' => $i]));
+            if ($i == $page) {
+                echo '<li class="active"><span>' . $i . '</span></li>';
+            } else {
+                echo '<li><a href="' . $pageNumUrl . '">' . $i . '</a></li>';
+            }
+        }
+        
+        if ($end_page < $total_pages) {
+            if ($end_page < $total_pages - 1) {
+                echo '<li class="disabled"><span>...</span></li>';
+            }
+            $lastUrl = new moodle_url('/mod/selflearn/coursereport.php', array_merge($paginationParams, ['page' => $total_pages]));
+            echo '<li><a href="' . $lastUrl . '">' . $total_pages . '</a></li>';
+        }
+        
+        if ($page < $total_pages) {
+            $nextUrl = new moodle_url('/mod/selflearn/coursereport.php', array_merge($paginationParams, ['page' => ($page + 1)]));
+            echo '<li><a href="' . $nextUrl . '">' . get_string('report::next', 'selflearn') . '</a></li>';
+        } else {
+            echo '<li class="disabled"><span>' . get_string('report::next', 'selflearn') . '</span></li>';
+        }
+        
+        echo '</ul>';
+        echo '</div>';
+    }
+    
+    echo '</div>';
+    
+    // Legend
+    echo '<div class="legend-card">';
+    echo '<h5>' . get_string('report::legend_title', 'selflearn') . '</h5>';
+    echo '<ul>';
+    echo '<li>' . get_string('report::legend_excellent', 'selflearn') . '</li>';
+    echo '<li>' . get_string('report::legend_good', 'selflearn') . '</li>';
+    echo '<li>' . get_string('report::legend_needs_improvement', 'selflearn') . '</li>';
+    echo '<li>' . get_string('report::legend_not_enrolled', 'selflearn') . '</li>';
+    echo '</ul>';
+    echo '</div>';
+    
+    echo '</div>';
+}
+
+echo '</div>';
+
+echo $OUTPUT->footer();

--- a/coursereport.php
+++ b/coursereport.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * SelfLearn Progress Report - Minimalistic Professional Design
+ * SelfLearn Progress Report - Production Version
  * Shows detailed progress overview for all students in SelfLearn activities
  *
  * @package   selflearn
@@ -45,6 +45,7 @@ $modulename = 'selflearn';
 global $DB;
 $courses = [];
 $instances = [];
+
 foreach ($modinfo->get_instances_of($modulename) as $cm) {
     if ($cm->uservisible) {
         $info = $DB->get_record('selflearn', ['id' => $cm->instance]);
@@ -61,6 +62,7 @@ foreach ($modinfo->get_instances_of($modulename) as $cm) {
 // Get students
 $studentRoleId = 5;
 $students = [];
+
 foreach ($enrolled_users as $user) {
     if (user_has_role_assignment($user->id, $studentRoleId, $context->id)) {
         $student = new stdClass();
@@ -107,7 +109,7 @@ if ($data === false || $refresh) {
                 if ($value === null || $value === false || $value === "---") {                    
                     $combined[] = '---';
                 } else {
-                    $combined[] = intval($value);
+                    $combined[] = floatval($value);
                 }
             } else {
                 $combined[] = '---';
@@ -116,7 +118,7 @@ if ($data === false || $refresh) {
 
         if (isset($progress[$user->username]['total_average'])) {
             $avg = $progress[$user->username]['total_average'];
-            $combined[] = ($avg !== null && $avg !== false) ? intval($avg) : '---';
+            $combined[] = ($avg !== null && $avg !== false) ? floatval($avg) : '---';
         } else {
             $combined[] = '---';
         }
@@ -157,8 +159,8 @@ usort($filtered, function($a, $b) use ($sortby, $sortorder) {
         return $sortorder == 'ASC' ? strcmp($a[$index], $b[$index]) : strcmp($b[$index], $a[$index]);
     }
 
-    $aVal = ($a[$index] === '---' || $a[$index] === 'N/A') ? -1 : intval($a[$index]);
-    $bVal = ($b[$index] === '---' || $b[$index] === 'N/A') ? -1 : intval($b[$index]);
+    $aVal = ($a[$index] === '---' || $a[$index] === 'N/A') ? -1 : floatval($a[$index]);
+    $bVal = ($b[$index] === '---' || $b[$index] === 'N/A') ? -1 : floatval($b[$index]);
 
     return $sortorder == 'ASC' ? $aVal <=> $bVal : $bVal <=> $aVal;
 });
@@ -182,7 +184,7 @@ foreach ($filtered as $entry) {
     for ($i = 3; $i < count($entry) - 1; $i++) {
         if ($entry[$i] !== '---' && $entry[$i] !== 'N/A') {
             $has_any_enrollment = true;
-            $progress_value = intval($entry[$i]);
+            $progress_value = floatval($entry[$i]);
             $total_progress += $progress_value;
             $progress_count++;
         }
@@ -221,7 +223,7 @@ echo $OUTPUT->heading($pagetitle);
 // Last updated info
 if (isset($data->last_updated)) {
     $last_updated = userdate($data->last_updated, get_string('strftimerecent'));
-    echo '<div class="alert-info">';
+    echo '<div class="alert alert-info alert-block fade in">';
     echo '<p><strong>' . get_string('report::last_updated', 'selflearn') . '</strong> ' . $last_updated . '</p>';
     echo '<p>' . get_string('report::cache_info', 'selflearn') . '</p>';
     echo '</div>';
@@ -230,43 +232,51 @@ if (isset($data->last_updated)) {
 echo '<div class="report-wrapper">';
 
 // Top Statistics Bar
-echo '<div class="top-stats-bar">';
+echo '<div class="report-stats-grid">';
 
-echo '<div class="stat-box">';
-echo '<div class="stat-box-label">' . get_string('report::total_students', 'selflearn') . '</div>';
-echo '<div class="stat-box-value">' . $total_students . '</div>';
+echo '<div class="card report-stat-card">';
+echo '<div class="card-body">';
+echo '<div class="report-stat-label text-muted">' . get_string('report::total_students', 'selflearn') . '</div>';
+echo '<div class="report-stat-value">' . $total_students . '</div>';
+echo '</div>';
 echo '</div>';
 
-echo '<div class="stat-box">';
-echo '<div class="stat-box-label">' . get_string('report::enrolled_students', 'selflearn') . '</div>';
-echo '<div class="stat-box-value">' . $enrolled_students . '</div>';
+echo '<div class="card report-stat-card">';
+echo '<div class="card-body">';
+echo '<div class="report-stat-label text-muted">' . get_string('report::enrolled_students', 'selflearn') . '</div>';
+echo '<div class="report-stat-value">' . $enrolled_students . '</div>';
+echo '</div>';
 echo '</div>';
 
-echo '<div class="stat-box">';
-echo '<div class="stat-box-label">' . get_string('report::average_progress', 'selflearn') . '</div>';
-echo '<div class="stat-box-value">' . $avg_progress . '%</div>';
+echo '<div class="card report-stat-card">';
+echo '<div class="card-body">';
+echo '<div class="report-stat-label text-muted">' . get_string('report::average_progress', 'selflearn') . '</div>';
+echo '<div class="report-stat-value">' . number_format($avg_progress, 1) . '%</div>';
+echo '</div>';
 echo '</div>';
 
-echo '<div class="stat-box">';
-echo '<div class="stat-box-label">' . get_string('report::activities_count', 'selflearn') . '</div>';
-echo '<div class="stat-box-value">' . count($instances) . '</div>';
+echo '<div class="card report-stat-card">';
+echo '<div class="card-body">';
+echo '<div class="report-stat-label text-muted">' . get_string('report::activities_count', 'selflearn') . '</div>';
+echo '<div class="report-stat-value">' . count($instances) . '</div>';
+echo '</div>';
 echo '</div>';
 
 echo '</div>';
 
 // Controls Section
-echo '<div class="controls-section">';
+echo '<div class="report-controls">';
 
-echo '<div class="search-container">';
-echo '<form method="get" action="' . $pageurl->out_omit_querystring() . '">';
+echo '<div class="report-search">';
+echo '<form method="get" action="' . $pageurl->out_omit_querystring() . '" class="form-inline">';
 echo '<input type="hidden" name="id" value="' . $id . '">';
 echo '<input type="hidden" name="sortby" value="' . $sortby . '">';
 echo '<input type="hidden" name="sortorder" value="' . $sortorder . '">';
-echo '<input type="text" name="search" class="search-input" placeholder="' . get_string('report::search_placeholder', 'selflearn') . '" value="' . s($search) . '">';
+echo '<input type="text" name="search" class="form-control w-100" placeholder="' . get_string('report::search_placeholder', 'selflearn') . '" value="' . s($search) . '">';
 echo '</form>';
 echo '</div>';
 
-echo '<div class="action-buttons">';
+echo '<div class="report-actions">';
 $refreshurl = new moodle_url('/mod/selflearn/coursereport.php', ['id' => $id, 'refresh' => 1]);
 echo html_writer::link($refreshurl, get_string('report::refresh_data', 'selflearn'), ['class' => 'btn btn-secondary']);
 $exporturl = new moodle_url('/mod/selflearn/excelexport.php', ['id' => $id]);
@@ -277,14 +287,13 @@ echo '</div>';
 
 // Progress table
 if (empty($paginated_data)) {
-    echo '<div class="no-results">';
+    echo '<div class="alert alert-warning text-center" role="alert">';
     echo '<p>' . get_string('report::no_results', 'selflearn') . '</p>';
     echo '</div>';
 } else {
-    echo '<div class="table-container">';
     echo '<div class="table-responsive">';
-    echo '<table class="table selflearn_table">';
-    echo '<thead>';
+    echo '<table class="table table-striped table-hover generaltable">';
+    echo '<thead class="thead-dark">';
     echo '<tr>';
 
     $baseParams = ['id' => $id, 'page' => $page, 'perpage' => $perpage, 'search' => $search, 'sortorder' => $nextsortorder];
@@ -329,14 +338,14 @@ if (empty($paginated_data)) {
                 if ($value === '---' || $value === 'N/A') {
                     echo '<td class="text-muted"><em>' . $value . '</em></td>';
                 } else {
-                    $percentage = intval($value);
+                    $percentage = floatval($value);
                     $class = '';
                     if ($percentage >= 80) $class = 'text-success';
                     elseif ($percentage >= 60) $class = 'text-warning';
                     elseif ($percentage >= 0) $class = 'text-danger';
                     else $class = 'text-muted';
 
-                    echo '<td class="' . $class . '"><strong>' . $percentage . '%</strong></td>';
+                    echo '<td class="' . $class . '"><strong>' . number_format($percentage, 1) . '%</strong></td>';
                 }
             } else {
                 echo '<td>' . htmlspecialchars($value) . '</td>';
@@ -348,32 +357,32 @@ if (empty($paginated_data)) {
     echo '</tbody>';
     echo '</table>';
     echo '</div>';
-    echo '</div>';
 
     // Bottom Section: Pagination + Legend
-    echo '<div class="bottom-section">';
+    echo '<div class="report-bottom-layout">';
     
     // Pagination
     echo '<div class="pagination-wrapper">';
     
     if ($total_pages > 1) {
-        echo '<div class="pagination-container">';
+        echo '<div class="d-flex justify-content-between align-items-center my-3">';
         
         $start = $offset + 1;
         $end = min($offset + $perpage, $total_records);
-        echo '<div class="pagination-info">';
+        echo '<div class="report-pagination-info text-muted">';
         echo get_string('report::showing_entries', 'selflearn', ['start' => $start, 'end' => $end, 'total' => $total_records]);
         echo '</div>';
         
-        echo '<ul class="pagination">';
+        echo '<nav aria-label="Page navigation">';
+        echo '<ul class="pagination mb-0">';
         
         $paginationParams = ['id' => $id, 'sortby' => $sortby, 'sortorder' => $sortorder, 'perpage' => $perpage, 'search' => $search];
         
         if ($page > 1) {
             $prevUrl = new moodle_url('/mod/selflearn/coursereport.php', array_merge($paginationParams, ['page' => ($page - 1)]));
-            echo '<li><a href="' . $prevUrl . '">' . get_string('report::previous', 'selflearn') . '</a></li>';
+            echo '<li class="page-item"><a class="page-link" href="' . $prevUrl . '">' . get_string('report::previous', 'selflearn') . '</a></li>';
         } else {
-            echo '<li class="disabled"><span>' . get_string('report::previous', 'selflearn') . '</span></li>';
+            echo '<li class="page-item disabled"><span class="page-link">' . get_string('report::previous', 'selflearn') . '</span></li>';
         }
         
         $start_page = max(1, $page - 2);
@@ -381,51 +390,54 @@ if (empty($paginated_data)) {
         
         if ($start_page > 1) {
             $firstUrl = new moodle_url('/mod/selflearn/coursereport.php', array_merge($paginationParams, ['page' => 1]));
-            echo '<li><a href="' . $firstUrl . '">1</a></li>';
+            echo '<li class="page-item"><a class="page-link" href="' . $firstUrl . '">1</a></li>';
             if ($start_page > 2) {
-                echo '<li class="disabled"><span>...</span></li>';
+                echo '<li class="page-item disabled"><span class="page-link">...</span></li>';
             }
         }
         
         for ($i = $start_page; $i <= $end_page; $i++) {
             $pageNumUrl = new moodle_url('/mod/selflearn/coursereport.php', array_merge($paginationParams, ['page' => $i]));
             if ($i == $page) {
-                echo '<li class="active"><span>' . $i . '</span></li>';
+                echo '<li class="page-item active"><span class="page-link">' . $i . '</span></li>';
             } else {
-                echo '<li><a href="' . $pageNumUrl . '">' . $i . '</a></li>';
+                echo '<li class="page-item"><a class="page-link" href="' . $pageNumUrl . '">' . $i . '</a></li>';
             }
         }
         
         if ($end_page < $total_pages) {
             if ($end_page < $total_pages - 1) {
-                echo '<li class="disabled"><span>...</span></li>';
+                echo '<li class="page-item disabled"><span class="page-link">...</span></li>';
             }
             $lastUrl = new moodle_url('/mod/selflearn/coursereport.php', array_merge($paginationParams, ['page' => $total_pages]));
-            echo '<li><a href="' . $lastUrl . '">' . $total_pages . '</a></li>';
+            echo '<li class="page-item"><a class="page-link" href="' . $lastUrl . '">' . $total_pages . '</a></li>';
         }
         
         if ($page < $total_pages) {
             $nextUrl = new moodle_url('/mod/selflearn/coursereport.php', array_merge($paginationParams, ['page' => ($page + 1)]));
-            echo '<li><a href="' . $nextUrl . '">' . get_string('report::next', 'selflearn') . '</a></li>';
+            echo '<li class="page-item"><a class="page-link" href="' . $nextUrl . '">' . get_string('report::next', 'selflearn') . '</a></li>';
         } else {
-            echo '<li class="disabled"><span>' . get_string('report::next', 'selflearn') . '</span></li>';
+            echo '<li class="page-item disabled"><span class="page-link">' . get_string('report::next', 'selflearn') . '</span></li>';
         }
         
         echo '</ul>';
+        echo '</nav>';
         echo '</div>';
     }
     
     echo '</div>';
     
     // Legend
-    echo '<div class="legend-card">';
+    echo '<div class="card report-legend">';
+    echo '<div class="card-body">';
     echo '<h5>' . get_string('report::legend_title', 'selflearn') . '</h5>';
-    echo '<ul>';
+    echo '<ul class="list-unstyled mb-0">';
     echo '<li>' . get_string('report::legend_excellent', 'selflearn') . '</li>';
     echo '<li>' . get_string('report::legend_good', 'selflearn') . '</li>';
     echo '<li>' . get_string('report::legend_needs_improvement', 'selflearn') . '</li>';
     echo '<li>' . get_string('report::legend_not_enrolled', 'selflearn') . '</li>';
     echo '</ul>';
+    echo '</div>';
     echo '</div>';
     
     echo '</div>';

--- a/coursereport.php
+++ b/coursereport.php
@@ -94,6 +94,30 @@ $data = $cache->get($id);
 if ($data === false || $refresh) {
     $progress = selflearn_query_progress($students, $courses);
 
+
+    // Check if API returned an error
+    if (isset($progress['_error'])) {
+        $cache->delete($id);
+        echo $OUTPUT->header();
+        echo $OUTPUT->heading($pagetitle);
+        echo '<div class="alert alert-danger" role="alert">';
+
+        if ($progress['_error'] === 'unavailable') {
+            echo '<h4>' . get_string('report::selflearn_unavailable_title', 'selflearn') . '</h4>';
+            echo '<p>' . get_string('report::selflearn_unavailable_message', 'selflearn') . '</p>';
+        } else {
+            echo '<h4>' . get_string('report::selflearn_error_title', 'selflearn') . '</h4>';
+            echo '<p>' . get_string('report::selflearn_error_message', 'selflearn') . '</p>';
+        }
+
+        $refreshurl = new moodle_url('/mod/selflearn/coursereport.php', ['id' => $id, 'refresh' => 1]);
+        echo html_writer::link($refreshurl, get_string('report::refresh_data', 'selflearn'), ['class' => 'btn btn-primary mt-2']);
+        echo '</div>';
+        echo $OUTPUT->footer();
+        die();
+    }
+
+
     foreach ($students as $user) {
         $combined = [
             $user->firstname,
@@ -106,8 +130,10 @@ if ($data === false || $refresh) {
 
             if (isset($progress[$user->username]) && isset($progress[$user->username][$slug])) {
                 $value = $progress[$user->username][$slug];
-                if ($value === null || $value === false || $value === "---") {                    
+                if ($value === null || $value === false || $value === "---") {
                     $combined[] = '---';
+                } else if ($value === "Error") {
+                    $combined[] = 'N/A';
                 } else {
                     $combined[] = floatval($value);
                 }
@@ -118,7 +144,7 @@ if ($data === false || $refresh) {
 
         if (isset($progress[$user->username]['total_average'])) {
             $avg = $progress[$user->username]['total_average'];
-            $combined[] = ($avg !== null && $avg !== false) ? floatval($avg) : '---';
+            $combined[] = ($avg !== null && $avg !== false && $avg !== "---" && $avg !== "Error") ? floatval($avg) : '---';
         } else {
             $combined[] = '---';
         }
@@ -140,20 +166,20 @@ if ($data === false || $refresh) {
 $filtered = $merged;
 if (!empty($search)) {
     $search_lower = strtolower(trim($search));
-    $filtered = array_filter($merged, function($entry) use ($search_lower) {
+    $filtered = array_filter($merged, function ($entry) use ($search_lower) {
         $firstname = strtolower($entry[0]);
         $lastname = strtolower($entry[1]);
         $username = strtolower($entry[2]);
-        
+
         return (strpos($firstname, $search_lower) !== false ||
-                strpos($lastname, $search_lower) !== false ||
-                strpos($username, $search_lower) !== false);
+            strpos($lastname, $search_lower) !== false ||
+            strpos($username, $search_lower) !== false);
     });
     $filtered = array_values($filtered);
 }
 
 // Sort data
-usort($filtered, function($a, $b) use ($sortby, $sortorder) {
+usort($filtered, function ($a, $b) use ($sortby, $sortorder) {
     $index = $sortby;
     if ($index == 0 || $index == 1 || $index == 2) {
         return $sortorder == 'ASC' ? strcmp($a[$index], $b[$index]) : strcmp($b[$index], $a[$index]);
@@ -180,7 +206,7 @@ $progress_count = 0;
 
 foreach ($filtered as $entry) {
     $has_any_enrollment = false;
-    
+
     for ($i = 3; $i < count($entry) - 1; $i++) {
         if ($entry[$i] !== '---' && $entry[$i] !== 'N/A') {
             $has_any_enrollment = true;
@@ -201,8 +227,8 @@ $avg_progress = ($progress_count > 0) ? round($total_progress / $progress_count,
 global $PAGE, $OUTPUT;
 $pagetitle = get_string("report::title", "selflearn");
 $pageurl = new moodle_url('/mod/selflearn/coursereport.php', [
-    'id' => $id, 
-    'sortby' => $sortby, 
+    'id' => $id,
+    'sortby' => $sortby,
     'sortorder' => $sortorder,
     'page' => $page,
     'perpage' => $perpage,
@@ -297,32 +323,37 @@ if (empty($paginated_data)) {
     echo '<tr>';
 
     $baseParams = ['id' => $id, 'page' => $page, 'perpage' => $perpage, 'search' => $search, 'sortorder' => $nextsortorder];
-    
+
     $firstNameUrl = new moodle_url('/mod/selflearn/coursereport.php', array_merge($baseParams, ['sortby' => 0]));
     echo '<th><a href="' . $firstNameUrl . '">' . get_string("report::first_name", "selflearn");
-    if ($sortby == 0) echo ($sortorder == 'ASC') ? ' ↑' : ' ↓';
+    if ($sortby == 0)
+        echo ($sortorder == 'ASC') ? ' ↑' : ' ↓';
     echo '</a></th>';
 
     $lastNameUrl = new moodle_url('/mod/selflearn/coursereport.php', array_merge($baseParams, ['sortby' => 1]));
     echo '<th><a href="' . $lastNameUrl . '">' . get_string("report::last_name", "selflearn");
-    if ($sortby == 1) echo ($sortorder == 'ASC') ? ' ↑' : ' ↓';
+    if ($sortby == 1)
+        echo ($sortorder == 'ASC') ? ' ↑' : ' ↓';
     echo '</a></th>';
 
     $usernameUrl = new moodle_url('/mod/selflearn/coursereport.php', array_merge($baseParams, ['sortby' => 2]));
     echo '<th><a href="' . $usernameUrl . '">' . get_string('report::username', 'selflearn');
-    if ($sortby == 2) echo ($sortorder == 'ASC') ? ' ↑' : ' ↓';
+    if ($sortby == 2)
+        echo ($sortorder == 'ASC') ? ' ↑' : ' ↓';
     echo '</a></th>';
 
     for ($i = 0; $i < count($instances); $i++) {
         $activityUrl = new moodle_url('/mod/selflearn/coursereport.php', array_merge($baseParams, ['sortby' => ($i + 3)]));
         echo '<th><a href="' . $activityUrl . '">' . $instances[$i]["name"];
-        if ($sortby == ($i + 3)) echo ($sortorder == 'ASC') ? ' ↑' : ' ↓';
+        if ($sortby == ($i + 3))
+            echo ($sortorder == 'ASC') ? ' ↑' : ' ↓';
         echo '</a></th>';
     }
 
     $avgUrl = new moodle_url('/mod/selflearn/coursereport.php', array_merge($baseParams, ['sortby' => (count($instances) + 3)]));
     echo '<th><a href="' . $avgUrl . '">' . get_string('report::average', 'selflearn');
-    if ($sortby == (count($instances) + 3)) echo ($sortorder == 'ASC') ? ' ↑' : ' ↓';
+    if ($sortby == (count($instances) + 3))
+        echo ($sortorder == 'ASC') ? ' ↑' : ' ↓';
     echo '</a></th>';
 
     echo '</tr>';
@@ -335,15 +366,21 @@ if (empty($paginated_data)) {
             $value = $entry[$i];
 
             if ($i >= 3) {
-                if ($value === '---' || $value === 'N/A') {
+                if ($value === '---') {
                     echo '<td class="text-muted"><em>' . $value . '</em></td>';
+                } else if ($value === 'N/A') {
+                    echo '<td class="text-danger"><strong>' . $value . '</strong></td>';
                 } else {
                     $percentage = floatval($value);
                     $class = '';
-                    if ($percentage >= 80) $class = 'text-success';
-                    elseif ($percentage >= 60) $class = 'text-warning';
-                    elseif ($percentage >= 0) $class = 'text-danger';
-                    else $class = 'text-muted';
+                    if ($percentage >= 80)
+                        $class = 'text-success';
+                    elseif ($percentage >= 60)
+                        $class = 'text-warning';
+                    elseif ($percentage >= 0)
+                        $class = 'text-danger';
+                    else
+                        $class = 'text-muted';
 
                     echo '<td class="' . $class . '"><strong>' . number_format($percentage, 1) . '%</strong></td>';
                 }
@@ -360,34 +397,34 @@ if (empty($paginated_data)) {
 
     // Bottom Section: Pagination + Legend
     echo '<div class="report-bottom-layout">';
-    
+
     // Pagination
     echo '<div class="pagination-wrapper">';
-    
+
     if ($total_pages > 1) {
         echo '<div class="d-flex justify-content-between align-items-center my-3">';
-        
+
         $start = $offset + 1;
         $end = min($offset + $perpage, $total_records);
         echo '<div class="report-pagination-info text-muted">';
         echo get_string('report::showing_entries', 'selflearn', ['start' => $start, 'end' => $end, 'total' => $total_records]);
         echo '</div>';
-        
+
         echo '<nav aria-label="Page navigation">';
         echo '<ul class="pagination mb-0">';
-        
+
         $paginationParams = ['id' => $id, 'sortby' => $sortby, 'sortorder' => $sortorder, 'perpage' => $perpage, 'search' => $search];
-        
+
         if ($page > 1) {
             $prevUrl = new moodle_url('/mod/selflearn/coursereport.php', array_merge($paginationParams, ['page' => ($page - 1)]));
             echo '<li class="page-item"><a class="page-link" href="' . $prevUrl . '">' . get_string('report::previous', 'selflearn') . '</a></li>';
         } else {
             echo '<li class="page-item disabled"><span class="page-link">' . get_string('report::previous', 'selflearn') . '</span></li>';
         }
-        
+
         $start_page = max(1, $page - 2);
         $end_page = min($total_pages, $page + 2);
-        
+
         if ($start_page > 1) {
             $firstUrl = new moodle_url('/mod/selflearn/coursereport.php', array_merge($paginationParams, ['page' => 1]));
             echo '<li class="page-item"><a class="page-link" href="' . $firstUrl . '">1</a></li>';
@@ -395,7 +432,7 @@ if (empty($paginated_data)) {
                 echo '<li class="page-item disabled"><span class="page-link">...</span></li>';
             }
         }
-        
+
         for ($i = $start_page; $i <= $end_page; $i++) {
             $pageNumUrl = new moodle_url('/mod/selflearn/coursereport.php', array_merge($paginationParams, ['page' => $i]));
             if ($i == $page) {
@@ -404,7 +441,7 @@ if (empty($paginated_data)) {
                 echo '<li class="page-item"><a class="page-link" href="' . $pageNumUrl . '">' . $i . '</a></li>';
             }
         }
-        
+
         if ($end_page < $total_pages) {
             if ($end_page < $total_pages - 1) {
                 echo '<li class="page-item disabled"><span class="page-link">...</span></li>';
@@ -412,21 +449,21 @@ if (empty($paginated_data)) {
             $lastUrl = new moodle_url('/mod/selflearn/coursereport.php', array_merge($paginationParams, ['page' => $total_pages]));
             echo '<li class="page-item"><a class="page-link" href="' . $lastUrl . '">' . $total_pages . '</a></li>';
         }
-        
+
         if ($page < $total_pages) {
             $nextUrl = new moodle_url('/mod/selflearn/coursereport.php', array_merge($paginationParams, ['page' => ($page + 1)]));
             echo '<li class="page-item"><a class="page-link" href="' . $nextUrl . '">' . get_string('report::next', 'selflearn') . '</a></li>';
         } else {
             echo '<li class="page-item disabled"><span class="page-link">' . get_string('report::next', 'selflearn') . '</span></li>';
         }
-        
+
         echo '</ul>';
         echo '</nav>';
         echo '</div>';
     }
-    
+
     echo '</div>';
-    
+
     // Legend
     echo '<div class="card report-legend">';
     echo '<div class="card-body">';
@@ -436,10 +473,11 @@ if (empty($paginated_data)) {
     echo '<li>' . get_string('report::legend_good', 'selflearn') . '</li>';
     echo '<li>' . get_string('report::legend_needs_improvement', 'selflearn') . '</li>';
     echo '<li>' . get_string('report::legend_not_enrolled', 'selflearn') . '</li>';
+    echo '<li>' . get_string('report::legend_not_author', 'selflearn') . '</li>';
     echo '</ul>';
     echo '</div>';
     echo '</div>';
-    
+
     echo '</div>';
 }
 

--- a/coursereport.php
+++ b/coursereport.php
@@ -21,6 +21,7 @@ $search = optional_param('search', '', PARAM_TEXT);
 
 // Access + permissions
 $course = get_course($id);
+$coursefullname = $course->fullname;
 require_login($id);
 
 $context = context_course::instance($id);
@@ -86,6 +87,8 @@ if (empty($courses)) {
     echo $OUTPUT->footer();
     die();
 }
+
+$pagetitle = get_string("report::title", "selflearn");
 
 // Get or compute progress data
 $merged = [];
@@ -225,7 +228,6 @@ $avg_progress = ($progress_count > 0) ? round($total_progress / $progress_count,
 
 // Page setup
 global $PAGE, $OUTPUT;
-$pagetitle = get_string("report::title", "selflearn");
 $pageurl = new moodle_url('/mod/selflearn/coursereport.php', [
     'id' => $id,
     'sortby' => $sortby,
@@ -238,7 +240,7 @@ $PAGE->set_pagelayout('incourse');
 $PAGE->set_context($context);
 $PAGE->set_url($pageurl);
 $PAGE->set_title($pagetitle);
-$PAGE->set_heading(format_string($course->fullname, true, ['context' => $context]));
+$PAGE->set_heading(format_string($coursefullname, true, ['context' => $context]));
 $PAGE->add_body_class('limitedwidth');
 
 $PAGE->requires->css('/mod/selflearn/styles.css');

--- a/excelexport.php
+++ b/excelexport.php
@@ -18,7 +18,7 @@ function export_csv($data) {
     fprintf($output, chr(0xEF).chr(0xBB).chr(0xBF));
     
     // Add headers to the CSV
-    $header = array_merge([get_string("report::first_name", "selflearn"), get_string("report::last_name", "selflearn")], $data->courses, ['Σ']);
+    $header = array_merge([get_string("report::first_name", "selflearn"), get_string("report::last_name", "selflearn"), 'Username'], $data->courses, ['Average']);
     fputcsv($output, $header, ";");
     
     foreach ($data->data as $row) {

--- a/excelexport.php
+++ b/excelexport.php
@@ -20,7 +20,22 @@ $cache = cache::make('mod_selflearn', 'report_cache');
 $data = $cache->get($id);
 
 if ($data === false || empty($data->data)) {
-    throw new moodle_exception('error::no_data_available', 'selflearn');
+    $course = get_course($id);
+    $context = context_course::instance($id);
+    $PAGE->set_context($context);
+    $PAGE->set_url(new moodle_url('/mod/selflearn/excelexport.php', ['id' => $id]));
+    $PAGE->set_title(get_string('report::title', 'selflearn'));
+    $PAGE->set_heading(format_string($course->fullname, true, ['context' => $context]));
+
+    echo $OUTPUT->header();
+    echo '<div class="alert alert-warning" role="alert">';
+    echo '<h4>' . get_string('report::export_no_data_title', 'selflearn') . '</h4>';
+    echo '<p>' . get_string('report::export_no_data_message', 'selflearn') . '</p>';
+    $reporturl = new moodle_url('/mod/selflearn/coursereport.php', ['id' => $id, 'refresh' => 1]);
+    echo html_writer::link($reporturl, get_string('report::refresh_data', 'selflearn'), ['class' => 'btn btn-primary mt-2']);
+    echo '</div>';
+    echo $OUTPUT->footer();
+    die();
 }
 
 // Determine delimiter based on locale

--- a/excelexport.php
+++ b/excelexport.php
@@ -1,7 +1,7 @@
 <?php
 /**
- * SelfLearn Excel Export - German CSV Format
- * Exports progress report in German CSV format (semicolon separator, comma decimal)
+ * SelfLearn CSV Export
+ * Exports progress report using Moodle's built-in CSV writer (locale-aware)
  *
  * @package   selflearn
  * @copyright 2024 University of Hildesheim, Software Systems Engineering
@@ -9,6 +9,7 @@
  */
 
 require_once("../../config.php");
+require_once($CFG->libdir . '/csvlib.class.php');
 
 require_login();
 
@@ -18,82 +19,45 @@ $id = required_param('id', PARAM_INT); // Course Id.
 $cache = cache::make('mod_selflearn', 'report_cache');
 $data = $cache->get($id);
 
-// Check if data exists
 if ($data === false || empty($data->data)) {
-    print_error('error::no_data_available', 'selflearn');
+    throw new moodle_exception('error::no_data_available', 'selflearn');
 }
 
-// Export CSV
-export_german_csv($data);
+// Determine delimiter based on locale
+$decsep = get_string('decsep', 'langconfig');
+$delimiter = ($decsep === ',') ? 'semicolon' : 'comma';
 
-/**
- * Export data in German CSV format
- * - Semicolon (;) as column separator
- * - Comma (,) as decimal separator
- * - UTF-8 with BOM for Excel compatibility
- * 
- * @param object $data Cached report data
- */
-function export_german_csv($data) {
-    // Set headers for CSV download
-    header('Content-Type: text/csv; charset=UTF-8');
-    header('Content-Disposition: attachment; filename="SelfLearn-Report-' . date('Y-m-d') . '.csv"');
-    header('Pragma: no-cache');
-    header('Expires: 0');
-    
-    $output = fopen("php://output", "w");
-    
-    // Add UTF-8 BOM for Excel to recognize UTF-8 encoding
-    fprintf($output, chr(0xEF).chr(0xBB).chr(0xBF));
-    
-    // Add headers to the CSV
-    $header = array_merge(
-        [
-            get_string("report::first_name", "selflearn"), 
-            get_string("report::last_name", "selflearn"), 
-            get_string("report::username", "selflearn")
-        ], 
-        $data->courses, 
-        [get_string("report::average", "selflearn")]
-    );
-    fputcsv($output, $header, ";", '"');  // Added quote character
-    
-    // Export data rows
-    foreach ($data->data as $row) {
-        $formatted_row = format_row_for_german_csv($row);
-        fputcsv($output, $formatted_row, ";", '"');  // Added quote character
-    }
-    
-    fclose($output);
-    exit;
-}
+// Create Moodle's built-in CSV writer
+$csv = new csv_export_writer($delimiter);
+$csv->set_filename('SelfLearn-Report');
 
-/**
- * Format row data for German CSV format
- * Converts percentage values to German decimal format (comma separator)
- * 
- * @param array $row Single data row
- * @return array Formatted row
- */
-function format_row_for_german_csv($row) {
+// Add header row
+$header = array_merge(
+    [
+        get_string("report::first_name", "selflearn"),
+        get_string("report::last_name", "selflearn"),
+        get_string("report::username", "selflearn")
+    ],
+    $data->courses,
+    [get_string("report::average", "selflearn")]
+);
+$csv->add_data($header);
+
+// Add data rows
+foreach ($data->data as $row) {
     $formatted = [];
-    
     foreach ($row as $index => $value) {
         if ($index < 3) {
-            // Names and username - keep as is
             $formatted[] = $value;
         } else {
-            // Progress values
             if ($value === '---' || $value === 'N/A' || $value === null) {
                 $formatted[] = '---';
             } else {
-                // Always format with 1 decimal place and German comma
-                $number = floatval($value);
-                $formatted[] = number_format($number, 1, ',', '');
+                $formatted[] = number_format(floatval($value), 1, $decsep, '');
             }
         }
     }
-    
-    return $formatted;
+    $csv->add_data($formatted);
 }
-?>
+$csv->filename = 'SelfLearn-Report-' . date('Y-m-d') . '.csv';
+$csv->download_file();

--- a/excelexport.php
+++ b/excelexport.php
@@ -1,30 +1,99 @@
 <?php
+/**
+ * SelfLearn Excel Export - German CSV Format
+ * Exports progress report in German CSV format (semicolon separator, comma decimal)
+ *
+ * @package   selflearn
+ * @copyright 2024 University of Hildesheim, Software Systems Engineering
+ * @license   Apache License 2.0 (http://www.apache.org/licenses/LICENSE-2.0)
+ */
+
 require_once("../../config.php");
 
 require_login();
 
 $id = required_param('id', PARAM_INT); // Course Id.
+
+// Get cached data
 $cache = cache::make('mod_selflearn', 'report_cache');
 $data = $cache->get($id);
-export_csv($data);
 
+// Check if data exists
+if ($data === false || empty($data->data)) {
+    print_error('error::no_data_available', 'selflearn');
+}
 
-function export_csv($data) {
-    global $DB;
-    header('Content-Type: text/csv');
-    header('Content-Disposition: attachment; filename="SelfLearn-Report.csv"');
+// Export CSV
+export_german_csv($data);
+
+/**
+ * Export data in German CSV format
+ * - Semicolon (;) as column separator
+ * - Comma (,) as decimal separator
+ * - UTF-8 with BOM for Excel compatibility
+ * 
+ * @param object $data Cached report data
+ */
+function export_german_csv($data) {
+    // Set headers for CSV download
+    header('Content-Type: text/csv; charset=UTF-8');
+    header('Content-Disposition: attachment; filename="SelfLearn-Report-' . date('Y-m-d') . '.csv"');
+    header('Pragma: no-cache');
+    header('Expires: 0');
     
     $output = fopen("php://output", "w");
+    
+    // Add UTF-8 BOM for Excel to recognize UTF-8 encoding
     fprintf($output, chr(0xEF).chr(0xBB).chr(0xBF));
     
     // Add headers to the CSV
-    $header = array_merge([get_string("report::first_name", "selflearn"), get_string("report::last_name", "selflearn"), 'Username'], $data->courses, ['Average']);
-    fputcsv($output, $header, ";");
+    $header = array_merge(
+        [
+            get_string("report::first_name", "selflearn"), 
+            get_string("report::last_name", "selflearn"), 
+            get_string("report::username", "selflearn")
+        ], 
+        $data->courses, 
+        [get_string("report::average", "selflearn")]
+    );
+    fputcsv($output, $header, ";", '"');  // Added quote character
     
+    // Export data rows
     foreach ($data->data as $row) {
-        fputcsv($output, $row, ";");
+        $formatted_row = format_row_for_german_csv($row);
+        fputcsv($output, $formatted_row, ";", '"');  // Added quote character
     }
     
     fclose($output);
     exit;
 }
+
+/**
+ * Format row data for German CSV format
+ * Converts percentage values to German decimal format (comma separator)
+ * 
+ * @param array $row Single data row
+ * @return array Formatted row
+ */
+function format_row_for_german_csv($row) {
+    $formatted = [];
+    
+    foreach ($row as $index => $value) {
+        if ($index < 3) {
+            // Names and username - keep as is
+            $formatted[] = $value;
+        } else {
+            // Progress values
+            if ($value === '---' || $value === 'N/A' || $value === null) {
+                $formatted[] = '---';
+            } else {
+                // Always format with 1 decimal place and German comma
+                $number = floatval($value);
+                $formatted[] = number_format($number, 1, ',', '');
+            }
+        }
+    }
+    
+    return $formatted;
+}
+?>

--- a/lang/de/selflearn.php
+++ b/lang/de/selflearn.php
@@ -29,8 +29,9 @@ $string['error::rest_api_blocked'] = 'Fehler: Verbindung zu SelfLearn REST API b
 $string['error::wrong_role:author'] = 'Fehler: Für die angeforderte Aktion benötigen Sie die Rolle "Author" in der SelfLearn-Platform.';
 $string['error::unauthorized_user'] = 'Fehler: Sie benötigen einen SelfLearn Account für die angeforderte Aktion. Loggen Sie sich einmalig in der SelfLearn-Plattform ({$a->link}) ein, um fortzufahren.';
 $string['error::selflearn_not_reachable'] = 'Fehler: SelfLearn Plattform ist nichr erreichbar, dieses Problem kann nur durch einen Admin behoben werden.';
-$string['error::No SelfLearn Base URL configured'] = 'Fehler: SelfLearn Plattform URL unbekannt, dieses Problem kann nur durch einen Admin behoben werden.';
-$string['error::No OAuth2 provider configured'] = 'Fehler: Es wurde kein SelfLearn Authentifizierungsdienst konfiguriert, dieses Problem kann nur durch einen Admin behoben werden.';
+$string['error::No_SelfLearn_Base_URL_configured'] = 'Fehler: SelfLearn Plattform URL unbekannt, dieses Problem kann nur durch einen Admin behoben werden.';
+$string['error::No_OAuth2_provider_configured'] = 'Fehler: Es wurde kein SelfLearn Authentifizierungsdienst konfiguriert, dieses Problem kann nur durch einen Admin behoben werden.';
+$string['error::OAuth2_misconfigured'] = 'Fehler: Der SelfLearn Authentifizierungsdienst wurde fehlerhaft konfiguriert, dieses Problem kann nur durch einen Admin behoben werden.';
 
 // New strings for course report
 $string['report::refresh_data'] = 'Daten aktualisieren';

--- a/lang/de/selflearn.php
+++ b/lang/de/selflearn.php
@@ -53,4 +53,11 @@ $string['report::legend_excellent'] = '80% und mehr — Ausgezeichnet';
 $string['report::legend_good'] = '60–79% — Guter Fortschritt';
 $string['report::legend_needs_improvement'] = '0–59% — Verbesserungsbedarf';
 $string['report::legend_not_enrolled'] = 'Nicht im Kurs eingeschrieben';
+$string['report::legend_not_author'] = 'N/A — Kein Autor in SelfLearn';
+
+
+$string['report::selflearn_unavailable_title'] = 'SelfLearn-Plattform nicht erreichbar';
+$string['report::selflearn_unavailable_message'] = 'Die SelfLearn-Plattform ist derzeit nicht erreichbar. Es können keine Fortschrittsdaten angezeigt werden. Bitte versuchen Sie es später erneut.';
+$string['report::selflearn_error_title'] = 'SelfLearn-Berichtsfehler';
+$string['report::selflearn_error_message'] = 'Die Fortschrittsdaten konnten nicht von der SelfLearn-Plattform abgerufen werden. Dies kann daran liegen, dass Sie kein Autorenkonto auf SelfLearn haben oder die Verbindung blockiert wurde. Bitte versuchen Sie es erneut.';
 ?>

--- a/lang/de/selflearn.php
+++ b/lang/de/selflearn.php
@@ -60,4 +60,6 @@ $string['report::selflearn_unavailable_title'] = 'SelfLearn-Plattform nicht erre
 $string['report::selflearn_unavailable_message'] = 'Die SelfLearn-Plattform ist derzeit nicht erreichbar. Es können keine Fortschrittsdaten angezeigt werden. Bitte versuchen Sie es später erneut.';
 $string['report::selflearn_error_title'] = 'SelfLearn-Berichtsfehler';
 $string['report::selflearn_error_message'] = 'Die Fortschrittsdaten konnten nicht von der SelfLearn-Plattform abgerufen werden. Dies kann daran liegen, dass Sie kein Autorenkonto auf SelfLearn haben oder die Verbindung blockiert wurde. Bitte versuchen Sie es erneut.';
+$string['report::export_no_data_title'] = 'Keine Daten zum Exportieren verfügbar';
+$string['report::export_no_data_message'] = 'Es sind keine zwischengespeicherten Berichtsdaten zum Exportieren vorhanden. Bitte öffnen Sie die Berichtsseite und aktualisieren Sie die Daten zuerst.';
 ?>

--- a/lang/de/selflearn.php
+++ b/lang/de/selflearn.php
@@ -31,4 +31,25 @@ $string['error::unauthorized_user'] = 'Fehler: Sie benötigen einen SelfLearn Ac
 $string['error::selflearn_not_reachable'] = 'Fehler: SelfLearn Plattform ist nichr erreichbar, dieses Problem kann nur durch einen Admin behoben werden.';
 $string['error::No SelfLearn Base URL configured'] = 'Fehler: SelfLearn Plattform URL unbekannt, dieses Problem kann nur durch einen Admin behoben werden.';
 $string['error::No OAuth2 provider configured'] = 'Fehler: Es wurde kein SelfLearn Authentifizierungsdienst konfiguriert, dieses Problem kann nur durch einen Admin behoben werden.';
+
+// New strings for course report
+$string['report::refresh_data'] = 'Daten aktualisieren';
+$string['report::last_updated'] = 'Zuletzt aktualisiert:';
+$string['report::cache_info'] = 'Die Fortschrittsdaten werden aus Performance-Gründen zwischengespeichert. Klicken Sie auf "Daten aktualisieren", um die neuesten Informationen zu erhalten.';
+$string['report::total_students'] = 'Studierende insgesamt';
+$string['report::enrolled_students'] = 'Eingeschrieben';
+$string['report::average_progress'] = 'Durchschnittlicher Fortschritt';
+$string['report::activities_count'] = 'Aktivitäten';
+$string['report::search_placeholder'] = 'Nach Name oder Benutzername suchen';
+$string['report::no_results'] = 'Keine Studierenden gefunden, die den Suchkriterien entsprechen.';
+$string['report::username'] = 'Benutzername';
+$string['report::average'] = 'Durchschnitt';
+$string['report::showing_entries'] = 'Zeige {$a->start}–{$a->end} von {$a->total} Studierenden';
+$string['report::previous'] = 'Zurück';
+$string['report::next'] = 'Weiter';
+$string['report::legend_title'] = 'Fortschrittslegende';
+$string['report::legend_excellent'] = '80% und mehr — Ausgezeichnet';
+$string['report::legend_good'] = '60–79% — Guter Fortschritt';
+$string['report::legend_needs_improvement'] = '0–59% — Verbesserungsbedarf';
+$string['report::legend_not_enrolled'] = 'Nicht im Kurs eingeschrieben';
 ?>

--- a/lang/de/selflearn.php
+++ b/lang/de/selflearn.php
@@ -49,9 +49,9 @@ $string['report::showing_entries'] = 'Zeige {$a->start}–{$a->end} von {$a->tot
 $string['report::previous'] = 'Zurück';
 $string['report::next'] = 'Weiter';
 $string['report::legend_title'] = 'Fortschrittslegende';
-$string['report::legend_excellent'] = '80% und mehr — Ausgezeichnet';
-$string['report::legend_good'] = '60–79% — Guter Fortschritt';
-$string['report::legend_needs_improvement'] = '0–59% — Verbesserungsbedarf';
+$string['report::legend_excellent'] = '80% und mehr';
+$string['report::legend_good'] = '60–79%';
+$string['report::legend_needs_improvement'] = '0–59%';
 $string['report::legend_not_enrolled'] = 'Nicht im Kurs eingeschrieben';
 $string['report::legend_not_author'] = 'N/A — Kein Autor in SelfLearn';
 

--- a/lang/en/selflearn.php
+++ b/lang/en/selflearn.php
@@ -49,9 +49,9 @@ $string['report::showing_entries'] = 'Showing {$a->start}–{$a->end} of {$a->to
 $string['report::previous'] = 'Previous';
 $string['report::next'] = 'Next';
 $string['report::legend_title'] = 'Progress Legend';
-$string['report::legend_excellent'] = '80% and above — Excellent';
-$string['report::legend_good'] = '60–79% — Good Progress';
-$string['report::legend_needs_improvement'] = '0–59% — Needs Improvement';
+$string['report::legend_excellent'] = '80% and above';
+$string['report::legend_good'] = '60–79%';
+$string['report::legend_needs_improvement'] = '0–59%';
 $string['report::legend_not_enrolled'] = 'Not enrolled in SelfLearn';
 $string['report::legend_not_author'] = 'N/A — Not Author in SelfLearn';
 

--- a/lang/en/selflearn.php
+++ b/lang/en/selflearn.php
@@ -52,5 +52,11 @@ $string['report::legend_title'] = 'Progress Legend';
 $string['report::legend_excellent'] = '80% and above — Excellent';
 $string['report::legend_good'] = '60–79% — Good Progress';
 $string['report::legend_needs_improvement'] = '0–59% — Needs Improvement';
-$string['report::legend_not_enrolled'] = 'Not enrolled in course';
+$string['report::legend_not_enrolled'] = 'Not enrolled in SelfLearn';
+$string['report::legend_not_author'] = 'N/A — Not Author in SelfLearn';
+
+$string['report::selflearn_unavailable_title'] = 'SelfLearn Platform Unavailable';
+$string['report::selflearn_unavailable_message'] = 'The SelfLearn platform is currently not reachable. No progress data can be displayed. Please try again later.';
+$string['report::selflearn_error_title'] = 'SelfLearn Report Error';
+$string['report::selflearn_error_message'] = 'Unable to retrieve progress data from the SelfLearn platform. This may be because you do not have an author account on SelfLearn, or the connection was blocked. Please ensure you have a valid SelfLearn account and try again.';
 ?>

--- a/lang/en/selflearn.php
+++ b/lang/en/selflearn.php
@@ -27,10 +27,11 @@ $string['report::export_btn'] = 'Export';
 $string['error::rest_api_blocked_by_moodle'] = 'Error: SelfLearn REST API blocked by Moodle, please contact an administrator.';
 $string['error::rest_api_blocked'] = 'Error: Connection to SelfLearn REST API blocked. Reason: {reason}';
 $string['error::wrong_role:author'] = 'Error: You need to be a SelfLearn "Author" to perform the action.';
-$string['error::unauthorized_user'] = 'Fehler: You need a SelfLearn account. Please log into the SelfLearn platform ({$a->link}) once, before continuing your request.';
+$string['error::unauthorized_user'] = 'Error: You need a SelfLearn account. Please log into the SelfLearn platform ({$a->link}) once, before continuing your request.';
 $string['error::selflearn_not_reachable'] = 'Error: SelfLearn platform not reachable, please contact an administrator.';
-$string['error::No SelfLearn Base URL configured'] = 'Error: SelfLearn URL unknown, please contact an administrator.';
-$string['error::No OAuth2 provider configured'] = 'Error: No SelfLearn Auth provider configuered, please contact an administrator.';
+$string['error::No_SelfLearn_Base_URL_configured'] = 'Error: SelfLearn URL unknown, please contact an administrator.';
+$string['error::No_OAuth2_provider_configured'] = 'Error: No SelfLearn Auth provider configuered, please contact an administrator.';
+$string['error::OAuth2_misconfigured'] = 'Error: The SelfLearn authentication service is misconfigured, please contact an administrator.';
 
 // New strings for course report
 $string['report::refresh_data'] = 'Refresh Data';

--- a/lang/en/selflearn.php
+++ b/lang/en/selflearn.php
@@ -31,4 +31,25 @@ $string['error::unauthorized_user'] = 'Fehler: You need a SelfLearn account. Ple
 $string['error::selflearn_not_reachable'] = 'Error: SelfLearn platform not reachable, please contact an administrator.';
 $string['error::No SelfLearn Base URL configured'] = 'Error: SelfLearn URL unknown, please contact an administrator.';
 $string['error::No OAuth2 provider configured'] = 'Error: No SelfLearn Auth provider configuered, please contact an administrator.';
+
+// New strings for course report
+$string['report::refresh_data'] = 'Refresh Data';
+$string['report::last_updated'] = 'Last Updated:';
+$string['report::cache_info'] = 'Progress data is cached for performance. Click "Refresh Data" to get the latest information.';
+$string['report::total_students'] = 'Total Students';
+$string['report::enrolled_students'] = 'Enrolled';
+$string['report::average_progress'] = 'Average Progress';
+$string['report::activities_count'] = 'Activities';
+$string['report::search_placeholder'] = 'Search by name or username';
+$string['report::no_results'] = 'No students found matching your search criteria.';
+$string['report::username'] = 'Username';
+$string['report::average'] = 'Average';
+$string['report::showing_entries'] = 'Showing {$a->start}–{$a->end} of {$a->total} students';
+$string['report::previous'] = 'Previous';
+$string['report::next'] = 'Next';
+$string['report::legend_title'] = 'Progress Legend';
+$string['report::legend_excellent'] = '80% and above — Excellent';
+$string['report::legend_good'] = '60–79% — Good Progress';
+$string['report::legend_needs_improvement'] = '0–59% — Needs Improvement';
+$string['report::legend_not_enrolled'] = 'Not enrolled in course';
 ?>

--- a/lang/en/selflearn.php
+++ b/lang/en/selflearn.php
@@ -59,4 +59,6 @@ $string['report::selflearn_unavailable_title'] = 'SelfLearn Platform Unavailable
 $string['report::selflearn_unavailable_message'] = 'The SelfLearn platform is currently not reachable. No progress data can be displayed. Please try again later.';
 $string['report::selflearn_error_title'] = 'SelfLearn Report Error';
 $string['report::selflearn_error_message'] = 'Unable to retrieve progress data from the SelfLearn platform. This may be because you do not have an author account on SelfLearn, or the connection was blocked. Please ensure you have a valid SelfLearn account and try again.';
+$string['report::export_no_data_title'] = 'No Data Available for Export';
+$string['report::export_no_data_message'] = 'There is no cached report data to export. Please go to the report page and refresh the data first.';
 ?>

--- a/lib.php
+++ b/lib.php
@@ -11,20 +11,21 @@ defined('MOODLE_INTERNAL') || die();
 require_once($CFG->libdir . '/filelib.php');
 require_once(__DIR__ . '/classes/restclient.php');
 
-function selflearn_query_progress($users, $courses) {
+function selflearn_query_progress($users, $courses, $restclient = null) {
     $studentScores = [];
 
     if (empty($users) || empty($courses)) {
         return $studentScores;
     }
 
-    // Create REST client
-    try {
-        $restclient = new restclient();
-    } catch (Exception $e) {
-        // If we can't create REST client, return default scores
-        error_log("SelfLearn: Cannot create REST client - " . $e->getMessage());
-        return selflearn_get_fallback_progress($users, $courses);
+    // Create REST client (for testing)
+    if ($restclient === null) {
+        try {
+            $restclient = new restclient();
+        } catch (Exception $e) {
+            error_log("SelfLearn: Cannot create REST client - " . $e->getMessage());
+            return selflearn_get_fallback_progress($users, $courses);
+        }
     }
 
     // Extract usernames for API call

--- a/lib.php
+++ b/lib.php
@@ -9,28 +9,111 @@
  */
 defined('MOODLE_INTERNAL') || die();
 require_once($CFG->libdir . '/filelib.php');
+require_once(__DIR__ . '/classes/restclient.php');
 
 function selflearn_query_progress($users, $courses) {
     $studentScores = [];
 
+    if (empty($users) || empty($courses)) {
+        return $studentScores;
+    }
+
+    // Create REST client
+    try {
+        $restclient = new restclient();
+    } catch (Exception $e) {
+        // If we can't create REST client, return default scores
+        error_log("SelfLearn: Cannot create REST client - " . $e->getMessage());
+        return selflearn_get_fallback_progress($users, $courses);
+    }
+
+    // Extract usernames for API call
+    $usernames = array_map(function($user) {
+        return $user->username;
+    }, $users);
+
     foreach ($users as $user) {
         $totalScore = 0;
         $userScores = [];
+        $validCourses = 0;
 
         foreach ($courses as $course) {
-            // Generate a random score between 0 and 100
-            $score = rand(0, 100);
-            $userScores[$course["slug"]] = $score;
-            $totalScore += $score;
+            try {
+                // Get progress for this specific course and user
+                $progress_data = $restclient->selflearn_get_course_progress($course["slug"], [$user->username]);
+
+                // DEBUG: Log the API response
+                error_log("SelfLearn DEBUG: User=" . $user->username . ", Course=" . $course["slug"] . ", API Response=" . json_encode($progress_data));
+
+                $score = null;
+                $userFound = false;
+
+                // Check if API returned any data for this user
+                if (!empty($progress_data)) {
+                    foreach ($progress_data as $student_progress) {
+                        if ($student_progress['username'] === $user->username) {
+                            $score = $student_progress['progress'];
+                            $userFound = true;
+                            error_log("SelfLearn DEBUG: User FOUND in API response with progress=" . $score);
+                            break;
+                        }
+                    }
+                } else {
+                    error_log("SelfLearn DEBUG: API returned empty array for user=" . $user->username);
+                }
+
+                // Handle different cases based on API response
+                if (!$userFound) {
+                    // API returned empty array = user not enrolled in SelfLearn course
+                    $userScores[$course["slug"]] = "---";
+                    error_log("SelfLearn DEBUG: Setting --- for non-enrolled user=" . $user->username);
+                } else if ($score === null) {
+                    // User found but progress is null
+                    $userScores[$course["slug"]] = "---";
+                    error_log("SelfLearn DEBUG: Setting --- for user with null progress=" . $user->username);
+                } else {
+                    // User enrolled with actual progress (including 0%)
+                    $userScores[$course["slug"]] = $score;
+                    $totalScore += $score;
+                    $validCourses++;
+                    error_log("SelfLearn DEBUG: Setting progress=" . $score . " for enrolled user=" . $user->username);
+                }
+
+            } catch (Exception $e) {
+                // API error for this course
+                error_log("SelfLearn: API error for course " . $course["slug"] . " - " . $e->getMessage());
+                $userScores[$course["slug"]] = "Error";
+            }
         }
 
-        // Calculate the average score for the student
-        $averageScore = $totalScore / count($courses);
+        // Calculate average only for courses where student is enrolled
+        if ($validCourses > 0) {
+            $averageScore = $totalScore / $validCourses;
+            $userScores['total_average'] = round($averageScore, 2);
+        } else {
+            $userScores['total_average'] = "---";
+        }
 
-        // Add the average score to the user's scores
-        $userScores['total_average'] = round($averageScore, 2);
+        $studentScores[$user->username] = $userScores;
+    }
 
-        // Store the user's scores in the result array
+    return $studentScores;
+}
+
+/**
+ * Fallback function when SelfLearn API is unavailable
+ */
+function selflearn_get_fallback_progress($users, $courses) {
+    $studentScores = [];
+
+    foreach ($users as $user) {
+        $userScores = [];
+
+        foreach ($courses as $course) {
+            $userScores[$course["slug"]] = "SelfLearn unavailable";
+        }
+
+        $userScores['total_average'] = "---";
         $studentScores[$user->username] = $userScores;
     }
 
@@ -138,16 +221,17 @@ function mod_selflearn_extend_navigation_course($navigation, $course, $context):
         $config = get_config('mod_selflearn');
         if (!empty($config->selflearn_base_url)) {
             $authoring_url = new moodle_url($config->selflearn_base_url . "dashboard/author");
+            // $authoring_url = $config->selflearn_base_url . "dashboard/author";
 
             $settingsnode = navigation_node::create(get_string('menu::authoring_page_label', 'selflearn'), $authoring_url, navigation_node::TYPE_CUSTOM,
                 null, 'selflearn_authoring_page', new pix_icon('monologo', '', 'mod_selflearn'));
             $navigation->add_node($settingsnode);
         }
 
-        // // Progress report of students
-        // $report_page = new moodle_url('/mod/selflearn/coursereport.php', ['id' => $course->id]);
-        // $settingsnode = navigation_node::create(get_string('report::title', 'selflearn'), $report_page, navigation_node::TYPE_SETTING,
-        //     null, 'selflearn', new pix_icon('i/selflearn', ''));
-        // $navigation->add_node($settingsnode);
+        // Progress report of students
+        $report_page = new moodle_url('/mod/selflearn/coursereport.php', ['id' => $course->id]);
+        $settingsnode = navigation_node::create(get_string('report::title', 'selflearn'), $report_page, navigation_node::TYPE_SETTING,
+            null, 'selflearn', new pix_icon('i/selflearn', ''));
+        $navigation->add_node($settingsnode);
     }
 }

--- a/lib.php
+++ b/lib.php
@@ -33,11 +33,6 @@ function selflearn_query_progress($users, $courses, $restclient = null) {
     $failed_calls = 0;
     $last_error = '';
 
-    // Extract usernames for API call
-    $usernames = array_map(function($user) {
-        return $user->username;
-    }, $users);
-
     foreach ($users as $user) {
         $totalScore = 0;
         $userScores = [];
@@ -48,8 +43,6 @@ function selflearn_query_progress($users, $courses, $restclient = null) {
             try {
                 // Get progress for this specific course and user
                 $progress_data = $restclient->selflearn_get_course_progress($course["slug"], [$user->username]);
-
-
                 $score = null;
                 $userFound = false;
 

--- a/lib.php
+++ b/lib.php
@@ -18,15 +18,20 @@ function selflearn_query_progress($users, $courses, $restclient = null) {
         return $studentScores;
     }
 
-    // Create REST client (for testing)
+    // Create REST client
     if ($restclient === null) {
         try {
             $restclient = new restclient();
         } catch (Exception $e) {
             error_log("SelfLearn: Cannot create REST client - " . $e->getMessage());
-            return selflearn_get_fallback_progress($users, $courses);
+            return ['_error' => 'unavailable', '_message' => $e->getMessage()];
         }
     }
+
+    // Track if ALL API calls fail
+    $total_calls = 0;
+    $failed_calls = 0;
+    $last_error = '';
 
     // Extract usernames for API call
     $usernames = array_map(function($user) {
@@ -39,12 +44,11 @@ function selflearn_query_progress($users, $courses, $restclient = null) {
         $validCourses = 0;
 
         foreach ($courses as $course) {
+            $total_calls++;
             try {
                 // Get progress for this specific course and user
                 $progress_data = $restclient->selflearn_get_course_progress($course["slug"], [$user->username]);
 
-                // DEBUG: Log the API response
-                error_log("SelfLearn DEBUG: User=" . $user->username . ", Course=" . $course["slug"] . ", API Response=" . json_encode($progress_data));
 
                 $score = null;
                 $userFound = false;
@@ -55,35 +59,33 @@ function selflearn_query_progress($users, $courses, $restclient = null) {
                         if ($student_progress['username'] === $user->username) {
                             $score = $student_progress['progress'];
                             $userFound = true;
-                            error_log("SelfLearn DEBUG: User FOUND in API response with progress=" . $score);
                             break;
                         }
                     }
-                } else {
-                    error_log("SelfLearn DEBUG: API returned empty array for user=" . $user->username);
                 }
 
                 // Handle different cases based on API response
                 if (!$userFound) {
                     // API returned empty array = user not enrolled in SelfLearn course
                     $userScores[$course["slug"]] = "---";
-                    error_log("SelfLearn DEBUG: Setting --- for non-enrolled user=" . $user->username);
                 } else if ($score === null) {
                     // User found but progress is null
-                    $userScores[$course["slug"]] = "---";
-                    error_log("SelfLearn DEBUG: Setting --- for user with null progress=" . $user->username);
+                    $userScores[$course["slug"]] = 0;
+                    $totalScore += 0;
+                    $validCourses++;
                 } else {
                     // User enrolled with actual progress (including 0%)
                     $userScores[$course["slug"]] = $score;
                     $totalScore += $score;
                     $validCourses++;
-                    error_log("SelfLearn DEBUG: Setting progress=" . $score . " for enrolled user=" . $user->username);
                 }
 
             } catch (Exception $e) {
                 // API error for this course
                 error_log("SelfLearn: API error for course " . $course["slug"] . " - " . $e->getMessage());
                 $userScores[$course["slug"]] = "Error";
+                $failed_calls++;
+                $last_error = $e->getMessage();
             }
         }
 
@@ -96,6 +98,11 @@ function selflearn_query_progress($users, $courses, $restclient = null) {
         }
 
         $studentScores[$user->username] = $userScores;
+    }
+
+    // If ALL API calls failed, return error
+    if ($failed_calls > 0 && $failed_calls === $total_calls) {
+        return ['_error' => 'api_error', '_message' => $last_error];
     }
 
     return $studentScores;

--- a/styles.css
+++ b/styles.css
@@ -1,73 +1,537 @@
+/* SelfLearn Report Styles - Moodle Blue Theme */
+
+/* === GLOBAL RESET === */
+* {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+}
+
+/* === MAIN WRAPPER === */
+.report-wrapper {
+    max-width: 100%;
+    margin: 0 auto;
+    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
+}
+
+/* === TOP STATISTICS BAR === */
+.top-stats-bar {
+    display: grid;
+    grid-template-columns: repeat(4, 1fr);
+    gap: 1px;
+    background: #dee2e6;
+    border: 1px solid #dee2e6;
+    margin-bottom: 40px;
+    overflow: hidden;
+}
+
+.stat-box {
+    background: #ffffff;
+    padding: 32px 24px;
+    text-align: center;
+    transition: all 0.2s ease;
+    border-top: 3px solid transparent;
+}
+
+.stat-box:hover {
+    background: #f8f9fa;
+    border-top-color: #0f6cbf;
+}
+
+.stat-box-label {
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 1.2px;
+    color: #495057;
+    font-weight: 600;
+    margin-bottom: 12px;
+}
+
+.stat-box-value {
+    font-size: 40px;
+    font-weight: 300;
+    color: #0f6cbf;
+    line-height: 1;
+}
+
+/* === CONTROLS SECTION === */
+.controls-section {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    margin-bottom: 32px;
+    gap: 24px;
+}
+
+.search-container {
+    flex: 1;
+    max-width: 400px;
+}
+
+.search-input {
+    width: 100%;
+    padding: 12px 16px;
+    font-size: 15px;
+    border: 2px solid #ced4da;
+    background: #ffffff;
+    transition: all 0.2s ease;
+    font-family: inherit;
+    border-radius: 4px;
+}
+
+.search-input:focus {
+    outline: none;
+    border-color: #0f6cbf;
+    box-shadow: 0 0 0 3px rgba(15, 108, 191, 0.1);
+}
+
+.search-input::placeholder {
+    color: #6c757d;
+}
+
+/* === ACTION BUTTONS === */
+.action-buttons {
+    display: flex;
+    gap: 12px;
+}
+
+.btn {
+    padding: 12px 24px;
+    font-size: 14px;
+    font-weight: 500;
+    border: 1px solid #ced4da;
+    background: #ffffff;
+    color: #495057;
+    cursor: pointer;
+    transition: all 0.2s ease;
+    text-decoration: none;
+    display: inline-block;
+    font-family: inherit;
+    border-radius: 4px;
+}
+
+.btn:hover {
+    border-color: #0f6cbf;
+    background: #f8f9fa;
+    color: #0f6cbf;
+}
+
+.btn-primary {
+    background: #0f6cbf;
+    color: #ffffff;
+    border-color: #0f6cbf;
+}
+
+.btn-primary:hover {
+    background: #0a568c;
+    border-color: #0a568c;
+}
+
+.btn-secondary {
+    background: #6c757d;
+    color: #ffffff;
+    border-color: #6c757d;
+}
+
+.btn-secondary:hover {
+    background: #5a6268;
+    border-color: #545b62;
+}
+
+/* === TABLE CONTAINER === */
+.table-container {
+    background: #ffffff;
+    border: 1px solid #dee2e6;
+    margin-bottom: 40px;
+    border-radius: 4px;
+    overflow: hidden;
+}
+
+.table-responsive {
+    overflow-x: auto;
+    -webkit-overflow-scrolling: touch;
+}
+
 .selflearn_table {
     width: 100%;
     border-collapse: collapse;
-    margin: 25px 0;
-    font-size: 0.9em;
-    box-shadow: 0 0 20px rgba(0, 0, 0, 0.1);
+    background: #ffffff;
 }
 
 .selflearn_table thead th {
-    background-color: #f3f3f3;
-    color: #333;
+    background: #0f6cbf;
+    color: #ffffff;
+    padding: 16px 20px;
+    font-weight: 600;
+    font-size: 13px;
+    text-transform: uppercase;
+    letter-spacing: 0.8px;
+    border-bottom: 2px solid #0a568c;
     text-align: left;
-    padding: 10px 15px;
 }
 
-.selflearn_table td {
-    padding: 10px 15px;
-    text-align: left;
-    border-bottom: 1px solid #ddd;
+.selflearn_table thead th a {
+    color: #ffffff;
+    text-decoration: none;
+    display: block;
 }
 
-.selflearn_table tbody tr {
-    border-bottom: 1px solid #f3f3f3;
+.selflearn_table thead th a:hover {
+    color: #e3f2fd;
 }
 
-.selflearn_table tbody tr:last-of-type {
-    border-bottom: 2px solid #009879;
+.selflearn_table tbody td {
+    padding: 20px;
+    border-bottom: 1px solid #f3f4f6;
+    font-size: 15px;
+    color: #495057;
 }
 
-.selflearn_table tfoot td {
-    text-align: left;
-    padding: 10px 15px;
-    color: #555;
-    font-weight: bold;
+.selflearn_table tbody tr:last-child td {
+    border-bottom: none;
 }
 
-.selflearn_table .profile {
+.selflearn_table tbody tr:hover {
+    background: #f8f9fa;
+}
+
+/* Progress Values */
+.selflearn_table .text-success strong,
+.selflearn_table .text-warning strong,
+.selflearn_table .text-danger strong {
+    font-weight: 600;
+    font-size: 14px;
+}
+
+.selflearn_table .text-success strong {
+    color: #28a745;
+}
+
+.selflearn_table .text-warning strong {
+    color: #fd7e14;
+}
+
+.selflearn_table .text-danger strong {
+    color: #dc3545;
+}
+
+.selflearn_table .text-muted {
+    color: #6c757d;
+    font-weight: 400;
+}
+
+/* === BOTTOM SECTION === */
+.bottom-section {
+    display: grid;
+    grid-template-columns: 1fr 280px;
+    gap: 40px;
+    margin-top: 40px;
+}
+
+/* === PAGINATION === */
+.pagination-wrapper {
     display: flex;
+    flex-direction: column;
+    gap: 24px;
+}
+
+.pagination-container {
+    display: flex;
+    justify-content: space-between;
     align-items: center;
 }
 
-.selflearn_table .avatar {
+.pagination-info {
+    font-size: 14px;
+    color: #495057;
+    font-weight: 400;
+}
+
+.pagination {
+    display: flex;
+    list-style: none;
+    padding: 0;
+    margin: 0;
+    gap: 4px;
+}
+
+.pagination li {
     display: inline-block;
-    background-color: #ddd;
-    border-radius: 50%;
-    width: 35px;
-    height: 35px;
+}
+
+.pagination a,
+.pagination span {
+    padding: 10px 14px;
+    border: 1px solid #dee2e6;
+    background: #ffffff;
+    color: #495057;
+    text-decoration: none;
+    display: inline-block;
+    min-width: 42px;
     text-align: center;
-    line-height: 35px;
-    font-weight: bold;
-    color: #333;
-    margin-right: 10px;
-}
-
-.selflearn_table select {
-    padding: 5px;
+    font-weight: 500;
+    font-size: 14px;
+    transition: all 0.2s ease;
     border-radius: 4px;
-    border: 1px solid #ddd;
 }
 
-.selflearn_table a {
-    color: #007bff;
+.pagination a:hover {
+    border-color: #0f6cbf;
+    background: #e3f2fd;
+    color: #0f6cbf;
+}
+
+.pagination .active span {
+    background: #0f6cbf;
+    color: #ffffff;
+    border-color: #0f6cbf;
+}
+
+.pagination .disabled span {
+    color: #adb5bd;
+    background: #ffffff;
+    border-color: #dee2e6;
+    cursor: not-allowed;
+}
+
+/* === LEGEND === */
+.legend-card {
+    background: #ffffff;
+    border: 1px solid #dee2e6;
+    padding: 24px;
+    border-radius: 4px;
+    border-top: 3px solid #0f6cbf;
+}
+
+.legend-card h5 {
+    font-size: 12px;
+    text-transform: uppercase;
+    letter-spacing: 1.2px;
+    color: #0f6cbf;
+    font-weight: 700;
+    margin-bottom: 20px;
+    padding-bottom: 12px;
+    border-bottom: 1px solid #dee2e6;
+}
+
+.legend-card ul {
+    list-style: none;
+    padding: 0;
+    margin: 0;
+}
+
+.legend-card li {
+    padding: 12px 0;
+    font-size: 14px;
+    color: #495057;
+    display: flex;
+    align-items: center;
+    gap: 12px;
+    border-bottom: 1px solid #f8f9fa;
+}
+
+.legend-card li:last-child {
+    border-bottom: none;
+}
+
+.legend-card li::before {
+    content: '';
+    width: 12px;
+    height: 12px;
+    border-radius: 50%;
+    flex-shrink: 0;
+}
+
+.legend-card li:nth-child(1)::before {
+    background: #28a745;
+}
+
+.legend-card li:nth-child(2)::before {
+    background: #fd7e14;
+}
+
+.legend-card li:nth-child(3)::before {
+    background: #dc3545;
+}
+
+.legend-card li:nth-child(4)::before {
+    background: #6c757d;
+}
+
+/* === ALERT === */
+.alert-info {
+    background: #e3f2fd;
+    border-left: 4px solid #0f6cbf;
+    color: #495057;
+    padding: 20px 24px;
+    margin-bottom: 32px;
+    font-size: 14px;
+    line-height: 1.6;
+    border-radius: 4px;
+}
+
+.alert-info p {
+    margin: 0 0 8px 0;
+}
+
+.alert-info p:last-child {
+    margin-bottom: 0;
+}
+
+.alert-info strong {
+    font-weight: 600;
+    color: #0f6cbf;
+}
+
+/* === NO RESULTS === */
+.no-results {
+    text-align: center;
+    padding: 80px 40px;
+    color: #6c757d;
+    font-size: 16px;
+    background: #ffffff;
+    border: 1px solid #dee2e6;
+    border-radius: 4px;
+}
+
+/* === PAGE HEADING === */
+#page-content h2 {
+    font-size: 32px;
+    font-weight: 400;
+    color: #343a40;
+    margin-bottom: 32px;
+    letter-spacing: -0.5px;
+}
+
+/* === BREADCRUMB STYLING (Moodle specific) === */
+.breadcrumb {
+    background: transparent;
+    padding: 0;
+    margin-bottom: 20px;
+}
+
+.breadcrumb-item a {
+    color: #0f6cbf;
     text-decoration: none;
 }
 
-.selflearn_table a:hover {
+.breadcrumb-item a:hover {
+    color: #0a568c;
     text-decoration: underline;
 }
 
-.selflearn_table .average {
-    background-color: #f3f3f3;
-    font-size: 0.9em;
+/* === RESPONSIVE === */
+@media (max-width: 1024px) {
+    .bottom-section {
+        grid-template-columns: 1fr;
+    }
+    
+    .legend-card {
+        max-width: 600px;
+    }
+}
+
+@media (max-width: 768px) {
+    .top-stats-bar {
+        grid-template-columns: repeat(2, 1fr);
+    }
+    
+    .controls-section {
+        flex-direction: column;
+        align-items: stretch;
+    }
+    
+    .search-container {
+        max-width: 100%;
+    }
+    
+    .action-buttons {
+        width: 100%;
+        flex-direction: column;
+    }
+    
+    .btn {
+        width: 100%;
+        text-align: center;
+    }
+    
+    .pagination-container {
+        flex-direction: column;
+        gap: 16px;
+        text-align: center;
+    }
+    
+    .stat-box-value {
+        font-size: 32px;
+    }
+}
+
+@media (max-width: 576px) {
+    .top-stats-bar {
+        grid-template-columns: 1fr;
+    }
+    
+    .selflearn_table thead th,
+    .selflearn_table tbody td {
+        padding: 12px;
+        font-size: 13px;
+    }
+    
+    .stat-box {
+        padding: 24px 20px;
+    }
+}
+
+/* === PRINT === */
+@media print {
+    .action-buttons,
+    .search-container,
+    .controls-section,
+    .alert-info {
+        display: none;
+    }
+    
+    .pagination-wrapper {
+        display: none;
+    }
+    
+    .bottom-section {
+        grid-template-columns: 1fr;
+        page-break-before: always;
+    }
+    
+    .top-stats-bar,
+    .table-container,
+    .legend-card {
+        border: 1px solid #000;
+        box-shadow: none;
+    }
+    
+    .selflearn_table thead th {
+        background: #0f6cbf !important;
+        -webkit-print-color-adjust: exact;
+        print-color-adjust: exact;
+    }
+}
+
+/* === MOODLE INTEGRATION === */
+/* Ensure compatibility with Moodle's default styles */
+.path-mod-selflearn .report-wrapper {
+    margin-top: 20px;
+}
+
+/* Override Moodle's default table styling if needed */
+.path-mod-selflearn .selflearn_table {
+    margin-bottom: 0;
+}
+
+/* Ensure buttons match Moodle style */
+.path-mod-selflearn .btn {
+    line-height: 1.5;
+}
+
+/* Match Moodle's card styling */
+.path-mod-selflearn .stat-box,
+.path-mod-selflearn .legend-card {
+    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
 }

--- a/styles.css
+++ b/styles.css
@@ -1,340 +1,110 @@
-/* SelfLearn Report Styles - Moodle Blue Theme */
+/* SelfLearn Report Styles - Moodle Theme Compatible */
 
-/* === GLOBAL RESET === */
-* {
-    margin: 0;
-    padding: 0;
-    box-sizing: border-box;
-}
-
-/* === MAIN WRAPPER === */
-.report-wrapper {
-    max-width: 100%;
-    margin: 0 auto;
-    font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', Arial, sans-serif;
-}
+/* Minimal custom styles - relying on Moodle's Bootstrap classes */
 
 /* === TOP STATISTICS BAR === */
-.top-stats-bar {
+.report-stats-grid {
     display: grid;
-    grid-template-columns: repeat(4, 1fr);
-    gap: 1px;
-    background: #dee2e6;
-    border: 1px solid #dee2e6;
-    margin-bottom: 40px;
-    overflow: hidden;
+    grid-template-columns: repeat(auto-fit, minmax(200px, 1fr));
+    gap: 1rem;
+    margin-bottom: 2rem;
 }
 
-.stat-box {
-    background: #ffffff;
-    padding: 32px 24px;
+.report-stat-card {
+    padding: 1.5rem;
     text-align: center;
-    transition: all 0.2s ease;
-    border-top: 3px solid transparent;
+    border-top: 3px solid;
 }
 
-.stat-box:hover {
-    background: #f8f9fa;
+.report-stat-card:nth-child(1) {
     border-top-color: #0f6cbf;
 }
 
-.stat-box-label {
-    font-size: 12px;
-    text-transform: uppercase;
-    letter-spacing: 1.2px;
-    color: #495057;
-    font-weight: 600;
-    margin-bottom: 12px;
+.report-stat-card:nth-child(2) {
+    border-top-color: #28a745;
 }
 
-.stat-box-value {
-    font-size: 40px;
+.report-stat-card:nth-child(3) {
+    border-top-color: #17a2b8;
+}
+
+.report-stat-card:nth-child(4) {
+    border-top-color: #6c757d;
+}
+
+.report-stat-label {
+    font-size: 0.75rem;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    font-weight: 600;
+    margin-bottom: 0.5rem;
+    opacity: 0.8;
+}
+
+.report-stat-value {
+    font-size: 2rem;
     font-weight: 300;
     color: #0f6cbf;
-    line-height: 1;
 }
 
 /* === CONTROLS SECTION === */
-.controls-section {
+.report-controls {
     display: flex;
     justify-content: space-between;
     align-items: center;
-    margin-bottom: 32px;
-    gap: 24px;
+    gap: 1rem;
+    margin-bottom: 1.5rem;
+    flex-wrap: wrap;
 }
 
-.search-container {
+.report-search {
     flex: 1;
     max-width: 400px;
+    min-width: 250px;
 }
 
-.search-input {
-    width: 100%;
-    padding: 12px 16px;
-    font-size: 15px;
-    border: 2px solid #ced4da;
-    background: #ffffff;
-    transition: all 0.2s ease;
-    font-family: inherit;
-    border-radius: 4px;
-}
-
-.search-input:focus {
-    outline: none;
-    border-color: #0f6cbf;
-    box-shadow: 0 0 0 3px rgba(15, 108, 191, 0.1);
-}
-
-.search-input::placeholder {
-    color: #6c757d;
-}
-
-/* === ACTION BUTTONS === */
-.action-buttons {
+.report-actions {
     display: flex;
-    gap: 12px;
+    gap: 0.5rem;
 }
 
-.btn {
-    padding: 12px 24px;
-    font-size: 14px;
-    font-weight: 500;
-    border: 1px solid #ced4da;
-    background: #ffffff;
-    color: #495057;
-    cursor: pointer;
-    transition: all 0.2s ease;
-    text-decoration: none;
-    display: inline-block;
-    font-family: inherit;
-    border-radius: 4px;
-}
-
-.btn:hover {
-    border-color: #0f6cbf;
-    background: #f8f9fa;
-    color: #0f6cbf;
-}
-
-.btn-primary {
-    background: #0f6cbf;
-    color: #ffffff;
-    border-color: #0f6cbf;
-}
-
-.btn-primary:hover {
-    background: #0a568c;
-    border-color: #0a568c;
-}
-
-.btn-secondary {
-    background: #6c757d;
-    color: #ffffff;
-    border-color: #6c757d;
-}
-
-.btn-secondary:hover {
-    background: #5a6268;
-    border-color: #545b62;
-}
-
-/* === TABLE CONTAINER === */
-.table-container {
-    background: #ffffff;
-    border: 1px solid #dee2e6;
-    margin-bottom: 40px;
-    border-radius: 4px;
-    overflow: hidden;
-}
-
-.table-responsive {
-    overflow-x: auto;
-    -webkit-overflow-scrolling: touch;
-}
-
-.selflearn_table {
-    width: 100%;
-    border-collapse: collapse;
-    background: #ffffff;
-}
-
-.selflearn_table thead th {
-    background: #0f6cbf;
-    color: #ffffff;
-    padding: 16px 20px;
-    font-weight: 600;
-    font-size: 13px;
-    text-transform: uppercase;
-    letter-spacing: 0.8px;
-    border-bottom: 2px solid #0a568c;
-    text-align: left;
-}
-
-.selflearn_table thead th a {
-    color: #ffffff;
-    text-decoration: none;
-    display: block;
-}
-
-.selflearn_table thead th a:hover {
-    color: #e3f2fd;
-}
-
-.selflearn_table tbody td {
-    padding: 20px;
-    border-bottom: 1px solid #f3f4f6;
-    font-size: 15px;
-    color: #495057;
-}
-
-.selflearn_table tbody tr:last-child td {
-    border-bottom: none;
-}
-
-.selflearn_table tbody tr:hover {
-    background: #f8f9fa;
-}
-
-/* Progress Values */
-.selflearn_table .text-success strong,
-.selflearn_table .text-warning strong,
-.selflearn_table .text-danger strong {
-    font-weight: 600;
-    font-size: 14px;
-}
-
-.selflearn_table .text-success strong {
-    color: #28a745;
-}
-
-.selflearn_table .text-warning strong {
-    color: #fd7e14;
-}
-
-.selflearn_table .text-danger strong {
-    color: #dc3545;
-}
-
-.selflearn_table .text-muted {
-    color: #6c757d;
-    font-weight: 400;
-}
-
-/* === BOTTOM SECTION === */
-.bottom-section {
+/* === BOTTOM LAYOUT === */
+.report-bottom-layout {
     display: grid;
     grid-template-columns: 1fr 280px;
-    gap: 40px;
-    margin-top: 40px;
+    gap: 2rem;
+    margin-top: 2rem;
 }
 
-/* === PAGINATION === */
-.pagination-wrapper {
-    display: flex;
-    flex-direction: column;
-    gap: 24px;
-}
-
-.pagination-container {
-    display: flex;
-    justify-content: space-between;
-    align-items: center;
-}
-
-.pagination-info {
-    font-size: 14px;
-    color: #495057;
-    font-weight: 400;
-}
-
-.pagination {
-    display: flex;
-    list-style: none;
-    padding: 0;
-    margin: 0;
-    gap: 4px;
-}
-
-.pagination li {
-    display: inline-block;
-}
-
-.pagination a,
-.pagination span {
-    padding: 10px 14px;
-    border: 1px solid #dee2e6;
-    background: #ffffff;
-    color: #495057;
-    text-decoration: none;
-    display: inline-block;
-    min-width: 42px;
-    text-align: center;
-    font-weight: 500;
-    font-size: 14px;
-    transition: all 0.2s ease;
-    border-radius: 4px;
-}
-
-.pagination a:hover {
-    border-color: #0f6cbf;
-    background: #e3f2fd;
-    color: #0f6cbf;
-}
-
-.pagination .active span {
-    background: #0f6cbf;
-    color: #ffffff;
-    border-color: #0f6cbf;
-}
-
-.pagination .disabled span {
-    color: #adb5bd;
-    background: #ffffff;
-    border-color: #dee2e6;
-    cursor: not-allowed;
-}
-
-/* === LEGEND === */
-.legend-card {
-    background: #ffffff;
-    border: 1px solid #dee2e6;
-    padding: 24px;
-    border-radius: 4px;
+/* === LEGEND CARD === */
+.report-legend {
     border-top: 3px solid #0f6cbf;
 }
 
-.legend-card h5 {
-    font-size: 12px;
+.report-legend h5 {
+    font-size: 0.75rem;
     text-transform: uppercase;
-    letter-spacing: 1.2px;
-    color: #0f6cbf;
+    letter-spacing: 0.05em;
     font-weight: 700;
-    margin-bottom: 20px;
-    padding-bottom: 12px;
-    border-bottom: 1px solid #dee2e6;
+    color: #0f6cbf;
+    margin-bottom: 1rem;
+    padding-bottom: 0.75rem;
 }
 
-.legend-card ul {
+.report-legend ul {
     list-style: none;
     padding: 0;
     margin: 0;
 }
 
-.legend-card li {
-    padding: 12px 0;
-    font-size: 14px;
-    color: #495057;
+.report-legend li {
+    padding: 0.75rem 0;
     display: flex;
     align-items: center;
-    gap: 12px;
-    border-bottom: 1px solid #f8f9fa;
+    gap: 0.75rem;
 }
 
-.legend-card li:last-child {
-    border-bottom: none;
-}
-
-.legend-card li::before {
+.report-legend li::before {
     content: '';
     width: 12px;
     height: 12px;
@@ -342,196 +112,73 @@
     flex-shrink: 0;
 }
 
-.legend-card li:nth-child(1)::before {
+.report-legend li:nth-child(1)::before {
     background: #28a745;
 }
 
-.legend-card li:nth-child(2)::before {
+.report-legend li:nth-child(2)::before {
     background: #fd7e14;
 }
 
-.legend-card li:nth-child(3)::before {
+.report-legend li:nth-child(3)::before {
     background: #dc3545;
 }
 
-.legend-card li:nth-child(4)::before {
+.report-legend li:nth-child(4)::before {
     background: #6c757d;
 }
 
-/* === ALERT === */
-.alert-info {
-    background: #e3f2fd;
-    border-left: 4px solid #0f6cbf;
-    color: #495057;
-    padding: 20px 24px;
-    margin-bottom: 32px;
-    font-size: 14px;
-    line-height: 1.6;
-    border-radius: 4px;
-}
-
-.alert-info p {
-    margin: 0 0 8px 0;
-}
-
-.alert-info p:last-child {
-    margin-bottom: 0;
-}
-
-.alert-info strong {
-    font-weight: 600;
-    color: #0f6cbf;
-}
-
-/* === NO RESULTS === */
-.no-results {
-    text-align: center;
-    padding: 80px 40px;
-    color: #6c757d;
-    font-size: 16px;
-    background: #ffffff;
-    border: 1px solid #dee2e6;
-    border-radius: 4px;
-}
-
-/* === PAGE HEADING === */
-#page-content h2 {
-    font-size: 32px;
-    font-weight: 400;
-    color: #343a40;
-    margin-bottom: 32px;
-    letter-spacing: -0.5px;
-}
-
-/* === BREADCRUMB STYLING (Moodle specific) === */
-.breadcrumb {
-    background: transparent;
-    padding: 0;
-    margin-bottom: 20px;
-}
-
-.breadcrumb-item a {
-    color: #0f6cbf;
-    text-decoration: none;
-}
-
-.breadcrumb-item a:hover {
-    color: #0a568c;
-    text-decoration: underline;
+/* === PAGINATION === */
+.report-pagination-info {
+    font-size: 0.875rem;
 }
 
 /* === RESPONSIVE === */
-@media (max-width: 1024px) {
-    .bottom-section {
+@media (max-width: 992px) {
+    .report-bottom-layout {
         grid-template-columns: 1fr;
     }
     
-    .legend-card {
+    .report-legend {
         max-width: 600px;
     }
 }
 
 @media (max-width: 768px) {
-    .top-stats-bar {
+    .report-stats-grid {
         grid-template-columns: repeat(2, 1fr);
     }
     
-    .controls-section {
+    .report-controls {
         flex-direction: column;
         align-items: stretch;
     }
     
-    .search-container {
+    .report-search {
         max-width: 100%;
     }
     
-    .action-buttons {
+    .report-actions {
         width: 100%;
         flex-direction: column;
-    }
-    
-    .btn {
-        width: 100%;
-        text-align: center;
-    }
-    
-    .pagination-container {
-        flex-direction: column;
-        gap: 16px;
-        text-align: center;
-    }
-    
-    .stat-box-value {
-        font-size: 32px;
     }
 }
 
 @media (max-width: 576px) {
-    .top-stats-bar {
+    .report-stats-grid {
         grid-template-columns: 1fr;
-    }
-    
-    .selflearn_table thead th,
-    .selflearn_table tbody td {
-        padding: 12px;
-        font-size: 13px;
-    }
-    
-    .stat-box {
-        padding: 24px 20px;
     }
 }
 
-/* === PRINT === */
+/* === PRINT STYLES === */
 @media print {
-    .action-buttons,
-    .search-container,
-    .controls-section,
-    .alert-info {
-        display: none;
+    .report-controls,
+    .alert {
+        display: none !important;
     }
     
-    .pagination-wrapper {
-        display: none;
-    }
-    
-    .bottom-section {
+    .report-bottom-layout {
         grid-template-columns: 1fr;
         page-break-before: always;
     }
-    
-    .top-stats-bar,
-    .table-container,
-    .legend-card {
-        border: 1px solid #000;
-        box-shadow: none;
-    }
-    
-    .selflearn_table thead th {
-        background: #0f6cbf !important;
-        -webkit-print-color-adjust: exact;
-        print-color-adjust: exact;
-    }
-}
-
-/* === MOODLE INTEGRATION === */
-/* Ensure compatibility with Moodle's default styles */
-.path-mod-selflearn .report-wrapper {
-    margin-top: 20px;
-}
-
-/* Override Moodle's default table styling if needed */
-.path-mod-selflearn .selflearn_table {
-    margin-bottom: 0;
-}
-
-/* Ensure buttons match Moodle style */
-.path-mod-selflearn .btn {
-    line-height: 1.5;
-}
-
-/* Match Moodle's card styling */
-.path-mod-selflearn .stat-box,
-.path-mod-selflearn .legend-card {
-    box-shadow: 0 1px 3px rgba(0, 0, 0, 0.12), 0 1px 2px rgba(0, 0, 0, 0.24);
 }

--- a/styles.css
+++ b/styles.css
@@ -128,6 +128,10 @@
     background: #6c757d;
 }
 
+.report-legend li:nth-child(5)::before {
+    background: #dc3545;
+}
+
 /* === PAGINATION === */
 .report-pagination-info {
     font-size: 0.875rem;

--- a/tests/integration_test.php
+++ b/tests/integration_test.php
@@ -1,0 +1,478 @@
+<?php
+namespace mod_selflearn;
+
+defined('MOODLE_INTERNAL') || die();
+
+require_once(__DIR__ . '/../lib.php');
+
+/**
+ * Integration tests for SelfLearn API functionality
+ * Tests the actual integration with external SelfLearn REST API
+ *
+ * @package    mod_selflearn
+ * @category   test
+ * @copyright  2024 University of Hildesheim
+ * @license    http://www.gnu.org/licenses/gpl-3.0.html GNU GPL v3 or later
+ */
+class integration_test extends \advanced_testcase {
+
+    /**
+     * Setup method - runs before each test
+     */
+    protected function setUp(): void {
+        parent::setUp();
+        $this->resetAfterTest(true);
+    }
+
+    // ========================================
+    // TEST 1: API Integration - Success Cases
+    // ========================================
+
+    /**
+     * Test 1.1: API returns progress for enrolled student
+     */
+    public function test_api_returns_progress_for_enrolled_student() {
+        // Create mock REST client
+        $mock_client = $this->createMock(\restclient::class);
+        
+        // Mock API response: student enrolled with 85% progress
+        $mock_client->method('selflearn_get_course_progress')
+            ->willReturn([
+                ['username' => 'student1', 'progress' => 85]
+            ]);
+
+        // Create test data
+        $users = [(object)['username' => 'student1']];
+        $courses = [['slug' => 'test-course', 'id' => 1]];
+
+        // Call function with mock client
+        $result = selflearn_query_progress($users, $courses, $mock_client);
+
+        // Assertions
+        $this->assertArrayHasKey('student1', $result);
+        $this->assertEquals(85, $result['student1']['test-course']);
+        $this->assertEquals(85, $result['student1']['total_average']);
+    }
+
+    /**
+     * Test 1.2: API returns empty array for non-enrolled student
+     */
+    public function test_api_returns_empty_for_not_enrolled() {
+        $mock_client = $this->createMock(\restclient::class);
+        
+        // Mock API response: empty array = not enrolled
+        $mock_client->method('selflearn_get_course_progress')
+            ->willReturn([]);
+
+        $users = [(object)['username' => 'student1']];
+        $courses = [['slug' => 'test-course', 'id' => 1]];
+
+        $result = selflearn_query_progress($users, $courses, $mock_client);
+
+        // Assertions
+        $this->assertArrayHasKey('student1', $result);
+        $this->assertEquals('---', $result['student1']['test-course']);
+        $this->assertEquals('---', $result['student1']['total_average']);
+    }
+
+    /**
+     * Test 1.3: API returns 0% progress (enrolled but no progress)
+     */
+    public function test_api_returns_zero_percent_progress() {
+        $mock_client = $this->createMock(\restclient::class);
+        
+        // Mock API response: 0% progress (enrolled but not started)
+        $mock_client->method('selflearn_get_course_progress')
+            ->willReturn([
+                ['username' => 'student1', 'progress' => 0]
+            ]);
+
+        $users = [(object)['username' => 'student1']];
+        $courses = [['slug' => 'test-course', 'id' => 1]];
+
+        $result = selflearn_query_progress($users, $courses, $mock_client);
+
+        // Assertions - 0% should be treated as enrolled with 0 progress
+        $this->assertArrayHasKey('student1', $result);
+        $this->assertEquals(0, $result['student1']['test-course']);
+        $this->assertEquals(0, $result['student1']['total_average']);
+    }
+
+    /**
+     * Test 1.4: Multiple students with different progress
+     */
+    public function test_multiple_students_different_progress() {
+        $mock_client = $this->createMock(\restclient::class);
+        
+        // Mock API responses for different students
+        $mock_client->method('selflearn_get_course_progress')
+            ->willReturnCallback(function($slug, $usernames) {
+                $username = $usernames[0];
+                
+                if ($username === 'student1') {
+                    return [['username' => 'student1', 'progress' => 85]];
+                } else if ($username === 'student2') {
+                    return [['username' => 'student2', 'progress' => 50]];
+                } else if ($username === 'student3') {
+                    return []; // Not enrolled
+                }
+                return [];
+            });
+
+        $users = [
+            (object)['username' => 'student1'],
+            (object)['username' => 'student2'],
+            (object)['username' => 'student3']
+        ];
+        $courses = [['slug' => 'test-course', 'id' => 1]];
+
+        $result = selflearn_query_progress($users, $courses, $mock_client);
+
+        // Assertions
+        $this->assertEquals(85, $result['student1']['test-course']);
+        $this->assertEquals(50, $result['student2']['test-course']);
+        $this->assertEquals('---', $result['student3']['test-course']);
+    }
+
+    /**
+     * Test 1.5: Multiple courses with different progress
+     */
+    public function test_multiple_courses_different_progress() {
+        $mock_client = $this->createMock(\restclient::class);
+        
+        // Mock API responses for different courses
+        $mock_client->method('selflearn_get_course_progress')
+            ->willReturnCallback(function($slug, $usernames) {
+                if ($slug === 'course1') {
+                    return [['username' => 'student1', 'progress' => 80]];
+                } else if ($slug === 'course2') {
+                    return [['username' => 'student1', 'progress' => 90]];
+                } else if ($slug === 'course3') {
+                    return []; // Not enrolled in course3
+                }
+                return [];
+            });
+
+        $users = [(object)['username' => 'student1']];
+        $courses = [
+            ['slug' => 'course1', 'id' => 1],
+            ['slug' => 'course2', 'id' => 2],
+            ['slug' => 'course3', 'id' => 3]
+        ];
+
+        $result = selflearn_query_progress($users, $courses, $mock_client);
+
+        // Assertions
+        $this->assertEquals(80, $result['student1']['course1']);
+        $this->assertEquals(90, $result['student1']['course2']);
+        $this->assertEquals('---', $result['student1']['course3']);
+        $this->assertEquals(85, $result['student1']['total_average']); // (80+90)/2 = 85
+    }
+
+    // ========================================
+    // TEST 2: Average Calculation
+    // ========================================
+
+    /**
+     * Test 2.1: Calculate average with all courses enrolled
+     */
+    public function test_average_all_courses_enrolled() {
+        $mock_client = $this->createMock(\restclient::class);
+        
+        $mock_client->method('selflearn_get_course_progress')
+            ->willReturnCallback(function($slug, $usernames) {
+                if ($slug === 'course1') {
+                    return [['username' => 'student1', 'progress' => 60]];
+                } else if ($slug === 'course2') {
+                    return [['username' => 'student1', 'progress' => 80]];
+                } else if ($slug === 'course3') {
+                    return [['username' => 'student1', 'progress' => 100]];
+                }
+                return [];
+            });
+
+        $users = [(object)['username' => 'student1']];
+        $courses = [
+            ['slug' => 'course1', 'id' => 1],
+            ['slug' => 'course2', 'id' => 2],
+            ['slug' => 'course3', 'id' => 3]
+        ];
+
+        $result = selflearn_query_progress($users, $courses, $mock_client);
+
+        // Average: (60+80+100)/3 = 80
+        $this->assertEquals(80, $result['student1']['total_average']);
+    }
+
+    /**
+     * Test 2.2: Calculate average excluding "---" (not enrolled) courses
+     */
+    public function test_average_excluding_not_enrolled() {
+        $mock_client = $this->createMock(\restclient::class);
+        
+        $mock_client->method('selflearn_get_course_progress')
+            ->willReturnCallback(function($slug, $usernames) {
+                if ($slug === 'course1') {
+                    return [['username' => 'student1', 'progress' => 70]];
+                } else if ($slug === 'course2') {
+                    return []; // Not enrolled
+                } else if ($slug === 'course3') {
+                    return [['username' => 'student1', 'progress' => 90]];
+                }
+                return [];
+            });
+
+        $users = [(object)['username' => 'student1']];
+        $courses = [
+            ['slug' => 'course1', 'id' => 1],
+            ['slug' => 'course2', 'id' => 2],
+            ['slug' => 'course3', 'id' => 3]
+        ];
+
+        $result = selflearn_query_progress($users, $courses, $mock_client);
+
+        // Average: (70+90)/2 = 80 (course2 not included)
+        $this->assertEquals(80, $result['student1']['total_average']);
+    }
+
+    /**
+     * Test 2.3: Average is "---" when not enrolled in any course
+     */
+    public function test_average_not_enrolled_in_any_course() {
+        $mock_client = $this->createMock(\restclient::class);
+        
+        // All courses return empty (not enrolled)
+        $mock_client->method('selflearn_get_course_progress')
+            ->willReturn([]);
+
+        $users = [(object)['username' => 'student1']];
+        $courses = [
+            ['slug' => 'course1', 'id' => 1],
+            ['slug' => 'course2', 'id' => 2]
+        ];
+
+        $result = selflearn_query_progress($users, $courses, $mock_client);
+
+        // Average should be "---" when not enrolled anywhere
+        $this->assertEquals('---', $result['student1']['total_average']);
+    }
+
+    /**
+     * Test 2.4: Average includes 0% progress
+     */
+    public function test_average_includes_zero_percent() {
+        $mock_client = $this->createMock(\restclient::class);
+        
+        $mock_client->method('selflearn_get_course_progress')
+            ->willReturnCallback(function($slug, $usernames) {
+                if ($slug === 'course1') {
+                    return [['username' => 'student1', 'progress' => 0]]; // 0%
+                } else if ($slug === 'course2') {
+                    return [['username' => 'student1', 'progress' => 100]];
+                }
+                return [];
+            });
+
+        $users = [(object)['username' => 'student1']];
+        $courses = [
+            ['slug' => 'course1', 'id' => 1],
+            ['slug' => 'course2', 'id' => 2]
+        ];
+
+        $result = selflearn_query_progress($users, $courses, $mock_client);
+
+        // Average: (0+100)/2 = 50
+        $this->assertEquals(50, $result['student1']['total_average']);
+    }
+
+    // ========================================
+    // TEST 3: Error Handling
+    // ========================================
+
+    /**
+     * Test 3.1: Handle API exception for specific course
+     */
+    public function test_api_exception_for_course() {
+        $mock_client = $this->createMock(\restclient::class);
+        
+        $mock_client->method('selflearn_get_course_progress')
+            ->willReturnCallback(function($slug, $usernames) {
+                if ($slug === 'course1') {
+                    return [['username' => 'student1', 'progress' => 80]];
+                } else if ($slug === 'course2') {
+                    throw new \Exception("API timeout");
+                }
+                return [];
+            });
+
+        $users = [(object)['username' => 'student1']];
+        $courses = [
+            ['slug' => 'course1', 'id' => 1],
+            ['slug' => 'course2', 'id' => 2]
+        ];
+
+        $result = selflearn_query_progress($users, $courses, $mock_client);
+
+        // Assertions
+        $this->assertEquals(80, $result['student1']['course1']);
+        $this->assertEquals('Error', $result['student1']['course2']);
+        // Average should only include successful courses
+        $this->assertEquals(80, $result['student1']['total_average']);
+    }
+
+    /**
+     * Test 3.2: Fallback when REST client cannot be created
+     */
+    public function test_fallback_when_restclient_fails() {
+        $users = [
+            (object)['username' => 'student1'],
+            (object)['username' => 'student2']
+        ];
+        $courses = [
+            ['slug' => 'course1', 'id' => 1],
+            ['slug' => 'course2', 'id' => 2]
+        ];
+
+        $result = selflearn_get_fallback_progress($users, $courses);
+
+        // Assertions - all should show "SelfLearn unavailable"
+        $this->assertEquals('SelfLearn unavailable', $result['student1']['course1']);
+        $this->assertEquals('SelfLearn unavailable', $result['student1']['course2']);
+        $this->assertEquals('---', $result['student1']['total_average']);
+        
+        $this->assertEquals('SelfLearn unavailable', $result['student2']['course1']);
+        $this->assertEquals('SelfLearn unavailable', $result['student2']['course2']);
+        $this->assertEquals('---', $result['student2']['total_average']);
+    }
+
+    // ========================================
+    // TEST 4: Edge Cases
+    // ========================================
+
+    /**
+     * Test 4.1: Empty users array
+     */
+    public function test_empty_users_array() {
+        $users = [];
+        $courses = [['slug' => 'course1', 'id' => 1]];
+
+        $result = selflearn_query_progress($users, $courses);
+
+        $this->assertEmpty($result);
+    }
+
+    /**
+     * Test 4.2: Empty courses array
+     */
+    public function test_empty_courses_array() {
+        $users = [(object)['username' => 'student1']];
+        $courses = [];
+
+        $result = selflearn_query_progress($users, $courses);
+
+        $this->assertEmpty($result);
+    }
+
+    /**
+     * Test 4.3: Both empty
+     */
+    public function test_both_arrays_empty() {
+        $users = [];
+        $courses = [];
+
+        $result = selflearn_query_progress($users, $courses);
+
+        $this->assertEmpty($result);
+    }
+
+    /**
+     * Test 4.4: API returns null progress
+     */
+    public function test_api_returns_null_progress() {
+        $mock_client = $this->createMock(\restclient::class);
+        
+        // Mock API response with null progress
+        $mock_client->method('selflearn_get_course_progress')
+            ->willReturn([
+                ['username' => 'student1', 'progress' => null]
+            ]);
+
+        $users = [(object)['username' => 'student1']];
+        $courses = [['slug' => 'test-course', 'id' => 1]];
+
+        $result = selflearn_query_progress($users, $courses, $mock_client);
+
+        // Null progress should be treated as "---"
+        $this->assertEquals('---', $result['student1']['test-course']);
+    }
+
+    /**
+     * Test 4.5: Large dataset (50 students, 5 courses)
+     */
+    public function test_large_dataset() {
+        $mock_client = $this->createMock(\restclient::class);
+        
+        $mock_client->method('selflearn_get_course_progress')
+            ->willReturnCallback(function($slug, $usernames) {
+                $username = $usernames[0];
+                // Simulate random progress
+                $progress = rand(0, 100);
+                return [['username' => $username, 'progress' => $progress]];
+            });
+
+        // Create 50 students
+        $users = [];
+        for ($i = 1; $i <= 50; $i++) {
+            $users[] = (object)['username' => 'student' . $i];
+        }
+
+        // Create 5 courses
+        $courses = [];
+        for ($i = 1; $i <= 5; $i++) {
+            $courses[] = ['slug' => 'course' . $i, 'id' => $i];
+        }
+
+        $result = selflearn_query_progress($users, $courses, $mock_client);
+
+        // Assertions
+        $this->assertCount(50, $result); // 50 students
+        
+        // Check each student has data for 5 courses + average
+        foreach ($result as $username => $data) {
+            $this->assertCount(6, $data); // 5 courses + total_average
+            $this->assertArrayHasKey('total_average', $data);
+        }
+    }
+
+    // ========================================
+    // TEST 5: Data Structure Validation
+    // ========================================
+
+    /**
+     * Test 5.1: Verify return data structure
+     */
+    public function test_return_data_structure() {
+        $mock_client = $this->createMock(\restclient::class);
+        
+        $mock_client->method('selflearn_get_course_progress')
+            ->willReturn([
+                ['username' => 'student1', 'progress' => 75]
+            ]);
+
+        $users = [(object)['username' => 'student1']];
+        $courses = [
+            ['slug' => 'course1', 'id' => 1],
+            ['slug' => 'course2', 'id' => 2]
+        ];
+
+        $result = selflearn_query_progress($users, $courses, $mock_client);
+
+        // Verify structure
+        $this->assertIsArray($result);
+        $this->assertArrayHasKey('student1', $result);
+        $this->assertIsArray($result['student1']);
+        $this->assertArrayHasKey('course1', $result['student1']);
+        $this->assertArrayHasKey('course2', $result['student1']);
+        $this->assertArrayHasKey('total_average', $result['student1']);
+    }
+}

--- a/tests/integration_test.php
+++ b/tests/integration_test.php
@@ -32,23 +32,19 @@ class integration_test extends \advanced_testcase {
      * Test 1.1: API returns progress for enrolled student
      */
     public function test_api_returns_progress_for_enrolled_student() {
-        // Create mock REST client
+        // Setup
         $mock_client = $this->createMock(\restclient::class);
-        
-        // Mock API response: student enrolled with 85% progress
         $mock_client->method('selflearn_get_course_progress')
             ->willReturn([
                 ['username' => 'student1', 'progress' => 85]
             ]);
-
-        // Create test data
         $users = [(object)['username' => 'student1']];
         $courses = [['slug' => 'test-course', 'id' => 1]];
 
-        // Call function with mock client
+        // Exercise
         $result = selflearn_query_progress($users, $courses, $mock_client);
 
-        // Assertions
+        // Verify
         $this->assertArrayHasKey('student1', $result);
         $this->assertEquals(85, $result['student1']['test-course']);
         $this->assertEquals(85, $result['student1']['total_average']);
@@ -58,18 +54,17 @@ class integration_test extends \advanced_testcase {
      * Test 1.2: API returns empty array for non-enrolled student
      */
     public function test_api_returns_empty_for_not_enrolled() {
+        // Setup
         $mock_client = $this->createMock(\restclient::class);
-        
-        // Mock API response: empty array = not enrolled
         $mock_client->method('selflearn_get_course_progress')
             ->willReturn([]);
-
         $users = [(object)['username' => 'student1']];
         $courses = [['slug' => 'test-course', 'id' => 1]];
 
+        // Exercise
         $result = selflearn_query_progress($users, $courses, $mock_client);
 
-        // Assertions
+        // Verify
         $this->assertArrayHasKey('student1', $result);
         $this->assertEquals('---', $result['student1']['test-course']);
         $this->assertEquals('---', $result['student1']['total_average']);
@@ -79,20 +74,19 @@ class integration_test extends \advanced_testcase {
      * Test 1.3: API returns 0% progress (enrolled but no progress)
      */
     public function test_api_returns_zero_percent_progress() {
+        // Setup
         $mock_client = $this->createMock(\restclient::class);
-        
-        // Mock API response: 0% progress (enrolled but not started)
         $mock_client->method('selflearn_get_course_progress')
             ->willReturn([
                 ['username' => 'student1', 'progress' => 0]
             ]);
-
         $users = [(object)['username' => 'student1']];
         $courses = [['slug' => 'test-course', 'id' => 1]];
 
+        // Exercise
         $result = selflearn_query_progress($users, $courses, $mock_client);
 
-        // Assertions - 0% should be treated as enrolled with 0 progress
+        // Verify
         $this->assertArrayHasKey('student1', $result);
         $this->assertEquals(0, $result['student1']['test-course']);
         $this->assertEquals(0, $result['student1']['total_average']);
@@ -102,9 +96,8 @@ class integration_test extends \advanced_testcase {
      * Test 1.4: Multiple students with different progress
      */
     public function test_multiple_students_different_progress() {
+        // Setup
         $mock_client = $this->createMock(\restclient::class);
-        
-        // Mock API responses for different students
         $mock_client->method('selflearn_get_course_progress')
             ->willReturnCallback(function($slug, $usernames) {
                 $username = $usernames[0];
@@ -118,7 +111,6 @@ class integration_test extends \advanced_testcase {
                 }
                 return [];
             });
-
         $users = [
             (object)['username' => 'student1'],
             (object)['username' => 'student2'],
@@ -126,9 +118,10 @@ class integration_test extends \advanced_testcase {
         ];
         $courses = [['slug' => 'test-course', 'id' => 1]];
 
+        // Exercise
         $result = selflearn_query_progress($users, $courses, $mock_client);
 
-        // Assertions
+        // Verify
         $this->assertEquals(85, $result['student1']['test-course']);
         $this->assertEquals(50, $result['student2']['test-course']);
         $this->assertEquals('---', $result['student3']['test-course']);
@@ -138,9 +131,8 @@ class integration_test extends \advanced_testcase {
      * Test 1.5: Multiple courses with different progress
      */
     public function test_multiple_courses_different_progress() {
+        // Setup
         $mock_client = $this->createMock(\restclient::class);
-        
-        // Mock API responses for different courses
         $mock_client->method('selflearn_get_course_progress')
             ->willReturnCallback(function($slug, $usernames) {
                 if ($slug === 'course1') {
@@ -152,7 +144,6 @@ class integration_test extends \advanced_testcase {
                 }
                 return [];
             });
-
         $users = [(object)['username' => 'student1']];
         $courses = [
             ['slug' => 'course1', 'id' => 1],
@@ -160,9 +151,10 @@ class integration_test extends \advanced_testcase {
             ['slug' => 'course3', 'id' => 3]
         ];
 
+        // Exercise
         $result = selflearn_query_progress($users, $courses, $mock_client);
 
-        // Assertions
+        // Verify
         $this->assertEquals(80, $result['student1']['course1']);
         $this->assertEquals(90, $result['student1']['course2']);
         $this->assertEquals('---', $result['student1']['course3']);
@@ -177,8 +169,8 @@ class integration_test extends \advanced_testcase {
      * Test 2.1: Calculate average with all courses enrolled
      */
     public function test_average_all_courses_enrolled() {
+        // Setup
         $mock_client = $this->createMock(\restclient::class);
-        
         $mock_client->method('selflearn_get_course_progress')
             ->willReturnCallback(function($slug, $usernames) {
                 if ($slug === 'course1') {
@@ -190,7 +182,6 @@ class integration_test extends \advanced_testcase {
                 }
                 return [];
             });
-
         $users = [(object)['username' => 'student1']];
         $courses = [
             ['slug' => 'course1', 'id' => 1],
@@ -198,9 +189,10 @@ class integration_test extends \advanced_testcase {
             ['slug' => 'course3', 'id' => 3]
         ];
 
+        // Exercise
         $result = selflearn_query_progress($users, $courses, $mock_client);
 
-        // Average: (60+80+100)/3 = 80
+        // Verify (60+80+100)/3 = 80
         $this->assertEquals(80, $result['student1']['total_average']);
     }
 
@@ -208,8 +200,8 @@ class integration_test extends \advanced_testcase {
      * Test 2.2: Calculate average excluding "---" (not enrolled) courses
      */
     public function test_average_excluding_not_enrolled() {
+        // Setup
         $mock_client = $this->createMock(\restclient::class);
-        
         $mock_client->method('selflearn_get_course_progress')
             ->willReturnCallback(function($slug, $usernames) {
                 if ($slug === 'course1') {
@@ -221,7 +213,6 @@ class integration_test extends \advanced_testcase {
                 }
                 return [];
             });
-
         $users = [(object)['username' => 'student1']];
         $courses = [
             ['slug' => 'course1', 'id' => 1],
@@ -229,9 +220,10 @@ class integration_test extends \advanced_testcase {
             ['slug' => 'course3', 'id' => 3]
         ];
 
+        // Exercise
         $result = selflearn_query_progress($users, $courses, $mock_client);
 
-        // Average: (70+90)/2 = 80 (course2 not included)
+        // Verify: (70+90)/2 = 80 (course2 not included)
         $this->assertEquals(80, $result['student1']['total_average']);
     }
 
@@ -239,9 +231,8 @@ class integration_test extends \advanced_testcase {
      * Test 2.3: Average is "---" when not enrolled in any course
      */
     public function test_average_not_enrolled_in_any_course() {
-        $mock_client = $this->createMock(\restclient::class);
-        
-        // All courses return empty (not enrolled)
+        // Setup
+        $mock_client = $this->createMock(\restclient::class);        
         $mock_client->method('selflearn_get_course_progress')
             ->willReturn([]);
 
@@ -251,9 +242,10 @@ class integration_test extends \advanced_testcase {
             ['slug' => 'course2', 'id' => 2]
         ];
 
+        // Exercise
         $result = selflearn_query_progress($users, $courses, $mock_client);
 
-        // Average should be "---" when not enrolled anywhere
+        // Verify
         $this->assertEquals('---', $result['student1']['total_average']);
     }
 
@@ -261,8 +253,8 @@ class integration_test extends \advanced_testcase {
      * Test 2.4: Average includes 0% progress
      */
     public function test_average_includes_zero_percent() {
+        // Setup
         $mock_client = $this->createMock(\restclient::class);
-        
         $mock_client->method('selflearn_get_course_progress')
             ->willReturnCallback(function($slug, $usernames) {
                 if ($slug === 'course1') {
@@ -272,16 +264,16 @@ class integration_test extends \advanced_testcase {
                 }
                 return [];
             });
-
         $users = [(object)['username' => 'student1']];
         $courses = [
             ['slug' => 'course1', 'id' => 1],
             ['slug' => 'course2', 'id' => 2]
         ];
 
+        // Exercise
         $result = selflearn_query_progress($users, $courses, $mock_client);
 
-        // Average: (0+100)/2 = 50
+        // Verify (0+100)/2 = 50
         $this->assertEquals(50, $result['student1']['total_average']);
     }
 
@@ -293,8 +285,8 @@ class integration_test extends \advanced_testcase {
      * Test 3.1: Handle API exception for specific course
      */
     public function test_api_exception_for_course() {
+        // Setup
         $mock_client = $this->createMock(\restclient::class);
-        
         $mock_client->method('selflearn_get_course_progress')
             ->willReturnCallback(function($slug, $usernames) {
                 if ($slug === 'course1') {
@@ -304,16 +296,16 @@ class integration_test extends \advanced_testcase {
                 }
                 return [];
             });
-
         $users = [(object)['username' => 'student1']];
         $courses = [
             ['slug' => 'course1', 'id' => 1],
             ['slug' => 'course2', 'id' => 2]
         ];
 
+        // Exercise
         $result = selflearn_query_progress($users, $courses, $mock_client);
 
-        // Assertions
+        // Verify
         $this->assertEquals(80, $result['student1']['course1']);
         $this->assertEquals('Error', $result['student1']['course2']);
         // Average should only include successful courses
@@ -324,6 +316,7 @@ class integration_test extends \advanced_testcase {
      * Test 3.2: Fallback when REST client cannot be created
      */
     public function test_fallback_when_restclient_fails() {
+        // Setup
         $users = [
             (object)['username' => 'student1'],
             (object)['username' => 'student2']
@@ -333,9 +326,10 @@ class integration_test extends \advanced_testcase {
             ['slug' => 'course2', 'id' => 2]
         ];
 
+        // Exercise
         $result = selflearn_get_fallback_progress($users, $courses);
 
-        // Assertions - all should show "SelfLearn unavailable"
+        // Verify - all should show "SelfLearn unavailable"
         $this->assertEquals('SelfLearn unavailable', $result['student1']['course1']);
         $this->assertEquals('SelfLearn unavailable', $result['student1']['course2']);
         $this->assertEquals('---', $result['student1']['total_average']);
@@ -353,11 +347,14 @@ class integration_test extends \advanced_testcase {
      * Test 4.1: Empty users array
      */
     public function test_empty_users_array() {
+        // Setup
         $users = [];
         $courses = [['slug' => 'course1', 'id' => 1]];
 
+        // Exercise
         $result = selflearn_query_progress($users, $courses);
 
+        // Verify
         $this->assertEmpty($result);
     }
 
@@ -365,11 +362,14 @@ class integration_test extends \advanced_testcase {
      * Test 4.2: Empty courses array
      */
     public function test_empty_courses_array() {
+        // Setup
         $users = [(object)['username' => 'student1']];
         $courses = [];
 
+        // Exercise
         $result = selflearn_query_progress($users, $courses);
 
+        // Verify
         $this->assertEmpty($result);
     }
 
@@ -377,11 +377,14 @@ class integration_test extends \advanced_testcase {
      * Test 4.3: Both empty
      */
     public function test_both_arrays_empty() {
+        // Setup
         $users = [];
         $courses = [];
 
+        // Exercise
         $result = selflearn_query_progress($users, $courses);
 
+        // Verify
         $this->assertEmpty($result);
     }
 
@@ -389,29 +392,29 @@ class integration_test extends \advanced_testcase {
      * Test 4.4: API returns null progress
      */
     public function test_api_returns_null_progress() {
+        // Setup
         $mock_client = $this->createMock(\restclient::class);
-        
-        // Mock API response with null progress
         $mock_client->method('selflearn_get_course_progress')
             ->willReturn([
                 ['username' => 'student1', 'progress' => null]
             ]);
-
         $users = [(object)['username' => 'student1']];
         $courses = [['slug' => 'test-course', 'id' => 1]];
 
+        // Exercise
         $result = selflearn_query_progress($users, $courses, $mock_client);
 
-        // Null progress should be treated as "---"
-        $this->assertEquals('---', $result['student1']['test-course']);
+        // Verify - enrolled but no progress, treated as 0%
+        $this->assertEquals(0, $result['student1']['test-course']);
+        $this->assertEquals(0, $result['student1']['total_average']);
     }
 
     /**
      * Test 4.5: Large dataset (50 students, 5 courses)
      */
     public function test_large_dataset() {
+        // Setup
         $mock_client = $this->createMock(\restclient::class);
-        
         $mock_client->method('selflearn_get_course_progress')
             ->willReturnCallback(function($slug, $usernames) {
                 $username = $usernames[0];
@@ -419,24 +422,22 @@ class integration_test extends \advanced_testcase {
                 $progress = rand(0, 100);
                 return [['username' => $username, 'progress' => $progress]];
             });
-
         // Create 50 students
         $users = [];
         for ($i = 1; $i <= 50; $i++) {
             $users[] = (object)['username' => 'student' . $i];
         }
-
         // Create 5 courses
         $courses = [];
         for ($i = 1; $i <= 5; $i++) {
             $courses[] = ['slug' => 'course' . $i, 'id' => $i];
         }
 
+        // Exercise
         $result = selflearn_query_progress($users, $courses, $mock_client);
 
-        // Assertions
+        // Verify
         $this->assertCount(50, $result); // 50 students
-        
         // Check each student has data for 5 courses + average
         foreach ($result as $username => $data) {
             $this->assertCount(6, $data); // 5 courses + total_average
@@ -452,19 +453,19 @@ class integration_test extends \advanced_testcase {
      * Test 5.1: Verify return data structure
      */
     public function test_return_data_structure() {
+        // Setup
         $mock_client = $this->createMock(\restclient::class);
-        
         $mock_client->method('selflearn_get_course_progress')
             ->willReturn([
                 ['username' => 'student1', 'progress' => 75]
             ]);
-
         $users = [(object)['username' => 'student1']];
         $courses = [
             ['slug' => 'course1', 'id' => 1],
             ['slug' => 'course2', 'id' => 2]
         ];
 
+        // Exercise
         $result = selflearn_query_progress($users, $courses, $mock_client);
 
         // Verify structure


### PR DESCRIPTION
## Student Progress Report Implementation

This PR implements student progress reporting and comprehensive testing for the SelfLearn Moodle plugin.

### Features
- Fetches and displays student progress data from linked SelfLearn courses via REST API
- Full-width table showing progress for all enrolled students
- Only considers students enrolled in both Moodle and SelfLearn courses
- Displays "---" for non-enrolled students
- Excludes trainers/moderators from progress reports
- Proper permission checks and error handling

### Testing
Added comprehensive integration test suite with 17 test cases covering:
- Progress calculation for enrolled/non-enrolled students
- Multiple students and courses scenarios
- API exceptions and fallback mechanisms
- Edge cases (empty arrays, null progress, large datasets)
- Data structure validation


